### PR TITLE
Add missing value in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,7 @@ applications:
       SESSION_EXPIRY: ((session_expiry))
       SESSION_SECRET: ((session_secret))
       AM_YOUR_ACCOUNT_URL: ((am_your_account_url))
+      GTM_ID: ((gtm_id))
     routes:
       - route: ((route_name))
     services:


### PR DESCRIPTION
## What?

Add gtm id to manifest.

## Why?

As it is blank when deployed.
