### PR TITLE
GOVSI-822: Add missing production tfvars

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,4 +1,4 @@
-redis_service_plan = ""
+redis_service_plan = "large-ha-5.x"
 environment      = "production"
-cf_domain          = ""
+cf_domain          = "prod.auth.ida.digital.cabinet-office.gov.uk"
 your_account_url  = "https://www.gov.uk/account/home"


### PR DESCRIPTION
## What?

- Add missing values for `cf_domain` and `redis_service_plan`

## Why?

Deploy is failing because of missing variables.