### PR TITLE
GOVSI-822: Rename `prod` to `production` sub-domain

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,4 +1,4 @@
 redis_service_plan = "large-ha-5.x"
 environment      = "production"
-cf_domain          = "prod.auth.ida.digital.cabinet-office.gov.uk"
+cf_domain          = "production.auth.ida.digital.cabinet-office.gov.uk"
 your_account_url  = "https://www.gov.uk/account/home"


### PR DESCRIPTION
## What?

- Update `production.tfvars` to include renamed sub-domain.

## Why?

We have renamed the production sub-domain.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/56
