### PR TITLE
GOVSI-854 - Set the number of app instances as a variable

### DIFF
--- a/ci/tasks/generate-account-management-deployment-variables.yml
+++ b/ci/tasks/generate-account-management-deployment-variables.yml
@@ -18,6 +18,7 @@ params:
   PUBLISHING_API_URL: ((build-gov-accounts-api-url))
   PUBLISHING_API_URL_TOKEN: ((build-gov-accounts-api-token))
   ENVIRONMENT_NAME: build
+  APP_INSTANCES: 1
 run:
   path: /bin/sh
   args:
@@ -41,4 +42,5 @@ run:
       gtm_id: ${GTM_ID}
       publishing_api_url: ${PUBLISHING_API_URL}
       publishing_api_token: ${PUBLISHING_API_URL_TOKEN}
+      app_instances: ${APP_INSTANCES}
       EOF

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,7 @@ applications:
     path: di-authentication-account-management-frontend.zip
     command: yarn run start
     memory: 2G
+    instances: ((app_instances))
     buildpacks:
       - nodejs_buildpack
     env:


### PR DESCRIPTION
## What?

- Set the number of app instances as a variable
- Default to 1 in the generate-account-management-deployment-variables.yml and we can then override it in the pipeline

## Why?

- So we can prevent any downtime when deploying the account management frontend


## Related PRs

https://github.com/alphagov/di-infrastructure/pull/60
