### PR TITLE
BAU - Set the IsInternalService attribute to true

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -70,5 +70,8 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     ServiceType = {
       S = "MANDATORY"
     }
+    IsInternalService = {
+      N = "1"
+    }
   })
 }


### PR DESCRIPTION
## What?
 - Set the IsInternalService attribute to true
 
## Why?
- So that Account management is registered as an Internal Service
