### PR TITLE
Add in cookie consent to authorize request

### DIFF
--- a/src/components/start/start-controller.ts
+++ b/src/components/start/start-controller.ts
@@ -12,6 +12,7 @@ export async function startGet(req: Request, res: Response): Promise<void> {
     state: req.session.state,
     nonce: req.session.nonce,
     redirect_uri: req.oidc.metadata.redirect_uris[0],
+    cookie_consent: req.query.cookie_consent
   });
 
   res.redirect(authUrl);

--- a/src/components/start/tests/start-controller.test.ts
+++ b/src/components/start/tests/start-controller.test.ts
@@ -14,6 +14,7 @@ describe("start controller", () => {
     sandbox = sinon.createSandbox();
     req = {
       body: {},
+      query:{},
       session: { user: sinon.fake() },
       oidc: { authorizationUrl: sandbox.fake(), metadata: {} },
     };


### PR DESCRIPTION
## What?

Add in cookie consent to authorize request.

## Why?

To enable sharing of cookie consent across apps.

