### PR TITLE
Add requires auth flag to logout

### DIFF
--- a/src/components/logout/logout-routes.ts
+++ b/src/components/logout/logout-routes.ts
@@ -1,9 +1,10 @@
 import * as express from "express";
 import { logoutGet } from "./logout-controller";
 import { PATH_DATA } from "../../app.constants";
+import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 
 const router = express.Router();
 
-router.get(PATH_DATA.SIGN_OUT.url, logoutGet);
+router.get(PATH_DATA.SIGN_OUT.url, requiresAuthMiddleware, logoutGet);
 
 export { router as logoutRouter };


### PR DESCRIPTION
## What?

Add requires auth middleware to logout route.

## Why?

To fix a 502 bad gateway issue when user already logged out.
