### PR TITLE
Add missing user journey to data layer

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -187,6 +187,11 @@ var cookies = function (trackingId) {
   function getJourneyMapping(url) {
 
     const JOURNEY_DATA_LAYER_PATHS = {
+      "/manage-your-account": {
+        sessionjourney: {
+          journey: 'account management'
+        }
+      },
       "/enter-password?type=changeEmail": generateJourneySession('change email', 'start'),
       "/change-email": generateJourneySession('change email', 'middle'),
       "/check-your-email": generateJourneySession('change email', 'middle'),


### PR DESCRIPTION
## What?

Add missing user journey to data layer for journey tracking.

## Why?

Missed a required user session to track when users load up the account management page.

