### PR TITLE
BAU - Extract service domain to set ANALYTICS_COOKIE_DOMAIN

### DIFF
--- a/ci/tasks/generate-account-management-deployment-variables.yml
+++ b/ci/tasks/generate-account-management-deployment-variables.yml
@@ -30,10 +30,12 @@ run:
       AM_URL="$(jq -r .${ENVIRONMENT_NAME}_account_management_url.value < domain-terraform-outputs/domain-terraform-outputs.json)"
       AM_API_URL="https://$(jq -r .${ENVIRONMENT_NAME}_account_management_api_url.value < domain-terraform-outputs/domain-terraform-outputs.json)"
       AM_YOUR_ACCOUNT_URL="$(jq -r .account_management_your_account_url.value < terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json)"
+      ANALYTICS_COOKIE_DOMAIN="$(jq -r .${ENVIRONMENT_NAME}_service_domain.value < domain-terraform-outputs/domain-terraform-outputs.json)"
 
       cat <<EOF > di-account-management-deploy-variables/vars.yml
       api_base_url: ${API_URL}
       am_api_base_url: ${AM_API_URL}
+      analytics_cookie_domain: ${ANALYTICS_COOKIE_DOMAIN}
       session_expiry: ${SESSION_EXPIRY}
       session_secret: ${SESSION_SECRET}
       route_name: ${AM_URL}

--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -14,12 +14,12 @@ resource "random_string" "account_management_client_id" {
   upper   = true
   special = false
   number  = true
-  length = 32
+  length  = 32
 }
 
 data "aws_kms_public_key" "account_management_jwt_key" {
   depends_on = [aws_kms_key.account_management_jwt_key]
-  key_id = aws_kms_key.account_management_jwt_key.arn
+  key_id     = aws_kms_key.account_management_jwt_key.arn
 }
 
 data "aws_dynamodb_table" "client_registry_table" {
@@ -30,7 +30,7 @@ resource "aws_dynamodb_table_item" "account_management_client" {
   table_name = data.aws_dynamodb_table.client_registry_table.name
   hash_key   = data.aws_dynamodb_table.client_registry_table.hash_key
 
-  item     = jsonencode({
+  item = jsonencode({
     ClientID = {
       S = random_string.account_management_client_id.result
     }
@@ -40,8 +40,8 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     Contacts = {
       L = []
     }
-    SubjectType: {
-      "S": "public"
+    SubjectType : {
+      "S" : "public"
     }
     PostLogoutRedirectUrls = {
       L = [
@@ -58,7 +58,7 @@ resource "aws_dynamodb_table_item" "account_management_client" {
       ]
     }
     Scopes = {
-      L = [for scope in local.scopes:
+      L = [for scope in local.scopes :
         {
           S = scope
         }

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,4 +1,4 @@
 redis_service_plan = "tiny-ha-5_x"
-environment      = "build"
+environment        = "build"
 cf_domain          = "build.auth.ida.digital.cabinet-office.gov.uk"
-your_account_url  = ""
+your_account_url   = ""

--- a/ci/terraform/cf-data.tf
+++ b/ci/terraform/cf-data.tf
@@ -6,7 +6,3 @@ data "cloudfoundry_space" "space" {
   name = var.environment
   org  = data.cloudfoundry_org.org.id
 }
-
-data "cloudfoundry_domain" "cloudapps" {
-  name = var.cf_domain
-}

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,4 +1,4 @@
 redis_service_plan = "tiny-ha-5_x"
-environment      = "integration"
+environment        = "integration"
 cf_domain          = "integration.auth.ida.digital.cabinet-office.gov.uk"
-your_account_url  = "https://www.integration.publishing.service.gov.uk/account/home"
+your_account_url   = "https://www.integration.publishing.service.gov.uk/account/home"

--- a/ci/terraform/outputs.tf
+++ b/ci/terraform/outputs.tf
@@ -1,12 +1,12 @@
 output "account_management_client_details" {
   value = {
-    client_id             = random_string.account_management_client_id.result
-    client_name           = "${var.environment}-account-managment"
-    KMS_KEY_ID            = aws_kms_key.account_management_jwt_key.id
+    client_id   = random_string.account_management_client_id.result
+    client_name = "${var.environment}-account-managment"
+    KMS_KEY_ID  = aws_kms_key.account_management_jwt_key.id
   }
   sensitive = true
 }
 
 output "account_management_your_account_url" {
-  value = "${var.your_account_url}"
+  value = var.your_account_url
 }

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,4 +1,4 @@
 redis_service_plan = "large-ha-5_x"
-environment      = "production"
+environment        = "production"
 cf_domain          = "production.auth.ida.digital.cabinet-office.gov.uk"
-your_account_url  = "https://www.gov.uk/account/home"
+your_account_url   = "https://www.gov.uk/account/home"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -1,4 +1,4 @@
-cf_org_name = "gds-digital-identity-authentication"
-cf_domain = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
-environment = "sandpit"
-your_account_url  = "https://www.gov.uk/account/home"
+cf_org_name      = "gds-digital-identity-authentication"
+cf_domain        = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
+environment      = "sandpit"
+your_account_url = "https://www.gov.uk/account/home"

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.56.0"
     }
     random = {

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -32,6 +32,6 @@ variable "redis_service_plan" {
 }
 
 variable "your_account_url" {
-  type = string
+  type        = string
   description = "the url to the GOV.UK account - Your Account homepage"
 }


### PR DESCRIPTION
## What?

- Extract the service_domain from the domain outputs
- Run terraform fmt

## Why?

- So account management can set the ANALYTICS_COOKIE_DOMAIN
- So terraform is formatted 
