### PR TITLE
Add the session journey to the data layer before the gtm container is created

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -153,12 +153,6 @@ var cookies = function (trackingId) {
       }
     ];
 
-    function gtag(obj) {
-      dataLayer.push(obj);
-    }
-
-    gtag({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-
     function addSessionJourneyToDataLayer(url) {
       const sessionJourney = getJourneyMapping(url);
 
@@ -172,6 +166,12 @@ var cookies = function (trackingId) {
         : window.location.pathname
 
     addSessionJourneyToDataLayer(url);
+
+    function gtag(obj) {
+      dataLayer.push(obj);
+    }
+
+    gtag({ "gtm.start": new Date().getTime(), event: "gtm.js" });
   }
 
   function generateJourneySession(type, status) {


### PR DESCRIPTION
## What?

Push the session journey information to the data layer before the gtm.start tag is pushed to ensure the session journey is available before the google analytics is triggered.

## Why?

Ensure the user journey information is available from the data layer at the correct point.

