### PR TITLE
GOVSI-888: Get service domain from domain terraform state

### DIFF
--- a/ci/tasks/deploy-account-management.yml
+++ b/ci/tasks/deploy-account-management.yml
@@ -8,6 +8,9 @@ image_resource:
     password: ((docker-hub-password))    
 params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
+  DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
+  DNS_STATE_BUCKET: ((dns-state-bucket))
+  DNS_STATE_KEY: ((dns-state-key))
   STATE_BUCKET: digital-identity-dev-tfstate
   DEPLOY_ENVIRONMENT: build
   CF_USERNAME: ((cf-username))
@@ -35,6 +38,9 @@ run:
         -var "cf_username=${CF_USERNAME}" \
         -var "cf_password=${CF_PASSWORD}" \
         -var "cf_org_name=${CF_ORG_NAME}" \
+        -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
+        -var "dns_state_key=${DNS_STATE_KEY}" \
+        -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
         -var-file ${DEPLOY_ENVIRONMENT}.tfvars
 
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -46,14 +46,14 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     PostLogoutRedirectUrls = {
       L = [
         {
-          S = "https://account-management.${var.cf_domain}/account-deleted-confirmation"
+          S = "https://account-management.${local.service_domain}/account-deleted-confirmation"
         }
       ]
     }
     RedirectUrls = {
       L = [
         {
-          S = "https://account-management.${var.cf_domain}/auth/callback"
+          S = "https://account-management.${local.service_domain}/auth/callback"
         }
       ]
     }

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,4 +1,3 @@
 redis_service_plan = "tiny-ha-5_x"
 environment        = "build"
-cf_domain          = "build.auth.ida.digital.cabinet-office.gov.uk"
 your_account_url   = ""

--- a/ci/terraform/dns.tf
+++ b/ci/terraform/dns.tf
@@ -1,0 +1,14 @@
+data "terraform_remote_state" "dns" {
+  count   = var.service_domain == null ? 1 : 0
+  backend = "s3"
+  config = {
+    bucket   = var.dns_state_bucket
+    key      = var.dns_state_key
+    role_arn = var.dns_state_role
+    region   = var.aws_region
+  }
+}
+
+locals {
+  service_domain = var.service_domain == null ? lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_service_domain", "") : var.service_domain
+}

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,4 +1,3 @@
 redis_service_plan = "tiny-ha-5_x"
 environment        = "integration"
-cf_domain          = "integration.auth.ida.digital.cabinet-office.gov.uk"
 your_account_url   = "https://www.integration.publishing.service.gov.uk/account/home"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,4 +1,3 @@
 redis_service_plan = "large-ha-5_x"
 environment        = "production"
-cf_domain          = "production.auth.ida.digital.cabinet-office.gov.uk"
 your_account_url   = "https://www.gov.uk/account/home"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -1,4 +1,4 @@
 cf_org_name      = "gds-digital-identity-authentication"
-cf_domain        = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
+service_domain   = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
 environment      = "sandpit"
 your_account_url = "https://www.gov.uk/account/home"

--- a/ci/terraform/user-provided-services.tf
+++ b/ci/terraform/user-provided-services.tf
@@ -18,7 +18,7 @@ resource "cloudfoundry_user_provided_service" "idp" {
   credentials_json = jsonencode({
     client_id   = random_string.account_management_client_id.result
     client_name = "${var.environment}-account-managment"
-    idp_url     = "https://api.${var.cf_domain}"
+    idp_url     = "https://api.${local.service_domain}"
     scopes      = local.scopes
   })
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -18,11 +18,24 @@ variable "cf_org_name" {
   description = "target org"
 }
 
+variable "dns_state_bucket" {
+  default = ""
+}
+
+variable "dns_state_key" {
+  default = ""
+}
+
+variable "dns_state_role" {
+  default = ""
+}
+
 variable "environment" {
   description = "the name of the environment being deployed (e.g. sandpit, build), this also matches the PaaS space name"
 }
 
-variable "cf_domain" {
+variable "service_domain" {
+  default = null
 }
 
 variable "redis_service_plan" {


### PR DESCRIPTION
## What?

- Remove hard-coded DNS domain references and replace with terraform_remote_state pointing at the domain terraform

## Why?

We are swapping domains over and this saves us having to manually replace values
