### PR TITLE
Add new js script to setup navbar listener to control the menu button in mobile view

### DIFF
--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -2,6 +2,7 @@
   "use strict";
   function appInit(trackingId) {
     var cookies = window.GOVSignIn.Cookies(trackingId);
+    var navbar = window.GOVSignIn.Navbar();
 
     if (cookies.hasConsentForAnalytics()) {
       cookies.initAnalytics();
@@ -12,6 +13,8 @@
     } else {
       cookies.cookieBannerInit();
     }
+
+    navbar.navbarInit();
   }
   w.GOVSignIn.appInit = appInit;
 })(window);

--- a/src/assets/javascript/navbar.js
+++ b/src/assets/javascript/navbar.js
@@ -1,0 +1,27 @@
+var navbar = function () {
+    function navbarInit() {
+        var navMenuButton = document.querySelector(".govuk-header__menu-button");
+        var navList = document.querySelector(".govuk-header__navigation");
+
+        navMenuButton.addEventListener(
+            "click",
+            function (event) {
+                event.preventDefault();
+                if (navMenuButton.classList.contains("govuk-header__menu-button--open")) {
+                    navMenuButton.classList.remove("govuk-header__menu-button--open")
+                    navList.classList.remove("govuk-header__navigation--open")
+                } else {
+                    navMenuButton.classList.add("govuk-header__menu-button--open")
+                    navList.classList.add("govuk-header__navigation--open")
+                }
+            }.bind(this)
+        );
+    }
+
+    return {
+        navbarInit
+    };
+}
+
+window.GOVSignIn = window.GOVSignIn || {};
+window.GOVSignIn.Navbar = navbar;

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -109,6 +109,7 @@
 
 {% block bodyEnd %}
   <script type="text/javascript" src="/public/scripts/cookies.js"></script>
+  <script type="text/javascript" src="/public/scripts/navbar.js"></script>
   <script type="text/javascript"  src="/public/scripts/application.js"></script>
   <script type="text/javascript" nonce='{{scriptNonce}}'>window.GOVSignIn.appInit("{{gtmId}}")</script>
 {% endblock %}


### PR DESCRIPTION
## What?

Create a new navbar js file to setup and event listener on the mobile nav bar menu button in order to properly generate the correct classNames on click.

## Why?

The nav bar menu button currently doesn't work in mobile view.


