### PR TITLE
GOVSI-1053: Add Sonar coverage collection

### DIFF
--- a/.github/workflows/analyse-on-merge.yml
+++ b/.github/workflows/analyse-on-merge.yml
@@ -1,11 +1,8 @@
 name: Pre-merge checks
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
+  push:
+    branches:
+      - main
 
 jobs:
   run-tests:
@@ -46,8 +43,6 @@ jobs:
         run: yarn test:unit
       - name: Run integration tests
         run: yarn test:integration
-      - name: Run lint
-        run: yarn lint
       - name: Run test coverage
         run: yarn test:coverage
       - name: SonarCloud Scan

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:integration": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config  \"src/**/*-integration.test.ts\"",
     "test:unit": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config --exclude \"src/**/*-integration.test.ts\"  \"test/unit/**/*.test.ts\" --recursive \"src/**/*.test.ts\"",
     "test": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config  \"test/unit/**/*.test.ts\" --recursive \"src/**/*.test.ts\"",
-    "test:coverage": "nyc report",
+    "test:coverage": "nyc report --reporter=lcov --reporter=text",
     "watch-node": "nodemon -r dotenv/config --inspect=0.0.0.0:9229 dist/server.js | pino-pretty",
     "watch-ts": "tsc -w",
     "watch-sass": "sass --watch src/assets/scss/application.scss dist/public/style.css"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.projectKey=alphagov_di-authentication-account-management
+sonar.organization=alphagov
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=src/
+sonar.tests=test/
+
+sonar.sourceEncoding=UTF-8
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## What?

- Add a `sonar-project.properties` file
- Add `yarn test:coverage` task to GitHub Actions
- Add an analysis on merge to give coverage stats for `main`

## Why?

Analysis is being performed, but no coverage stats are being collected, we need to resolve this.
