### PR TITLE
GOVSI-1100 - Handle error when user changes password to current password

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -117,6 +117,10 @@ export const ERROR_MESSAGES = {
   PAGE_NOT_FOUND: "Request page not found",
 };
 
+export const ERROR_CODES = {
+  NEW_PASSWORD_SAME_AS_EXISTING: 1024,
+};
+
 export const ENVIRONMENT_NAME = {
   PROD: "production",
   DEV: "development",

--- a/src/components/change-password/change-password-controller.ts
+++ b/src/components/change-password/change-password-controller.ts
@@ -5,9 +5,10 @@ import { ChangePasswordServiceInterface } from "./types";
 import { changePasswordService } from "./change-password-service";
 import { getNextState } from "../../utils/state-machine";
 import {
-  formatValidationError,
   renderBadRequest,
+  formatValidationError,
 } from "../../utils/validation";
+import { BadRequestError } from "../../utils/errors";
 
 const changePasswordTemplate = "change-password/index.njk";
 
@@ -46,7 +47,7 @@ export function changePasswordPost(
       );
       return renderBadRequest(res, req, changePasswordTemplate, error);
     } else {
-      return res.render("common/errors/500.njk");
+      throw new BadRequestError(response.message, response.code);
     }
   };
 }

--- a/src/components/change-password/change-password-controller.ts
+++ b/src/components/change-password/change-password-controller.ts
@@ -1,12 +1,18 @@
 import { Request, Response } from "express";
 import { ExpressRouteFunc } from "../../types";
-import { PATH_DATA } from "../../app.constants";
+import { PATH_DATA, ERROR_CODES } from "../../app.constants";
 import { ChangePasswordServiceInterface } from "./types";
 import { changePasswordService } from "./change-password-service";
 import { getNextState } from "../../utils/state-machine";
+import {
+  formatValidationError,
+  renderBadRequest,
+} from "../../utils/validation";
+
+const changePasswordTemplate = "change-password/index.njk";
 
 export function changePasswordGet(req: Request, res: Response): void {
-  res.render("change-password/index.njk");
+  res.render(changePasswordTemplate);
 }
 
 export function changePasswordPost(
@@ -18,13 +24,29 @@ export function changePasswordPost(
 
     const newPassword = req.body.password as string;
 
-    await service.updatePassword(accessToken, email, newPassword, req.ip);
-
-    req.session.user.state.changePassword = getNextState(
-      req.session.user.state.changePassword.value,
-      "VALUE_UPDATED"
+    const response = await service.updatePassword(
+      accessToken,
+      email,
+      newPassword,
+      req.ip
     );
 
-    return res.redirect(PATH_DATA.PASSWORD_UPDATED_CONFIRMATION.url);
+    if (response.success) {
+      req.session.user.state.changePassword = getNextState(
+        req.session.user.state.changePassword.value,
+        "VALUE_UPDATED"
+      );
+
+      return res.redirect(PATH_DATA.PASSWORD_UPDATED_CONFIRMATION.url);
+    }
+    if (response.code === ERROR_CODES.NEW_PASSWORD_SAME_AS_EXISTING) {
+      const error = formatValidationError(
+        "password",
+        req.t("pages.changePassword.password.validationError.samePassword")
+      );
+      return renderBadRequest(res, req, changePasswordTemplate, error);
+    } else {
+      return res.render("common/errors/500.njk");
+    }
   };
 }

--- a/src/components/change-password/change-password-service.ts
+++ b/src/components/change-password/change-password-service.ts
@@ -1,6 +1,12 @@
-import { getRequestConfig, Http, http } from "../../utils/http";
-import { API_ENDPOINTS } from "../../app.constants";
+import {
+  getRequestConfig,
+  Http,
+  http,
+  createApiResponse,
+} from "../../utils/http";
+import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
 import { ChangePasswordServiceInterface } from "./types";
+import { ApiResponse, ApiResponseResult } from "../../utils/types";
 
 export function changePasswordService(
   axios: Http = http
@@ -10,15 +16,20 @@ export function changePasswordService(
     email: string,
     newPassword: string,
     sourceIp: string
-  ): Promise<void> {
-    await axios.client.post<void>(
+  ): Promise<ApiResponseResult> {
+    const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.UPDATE_PASSWORD,
       {
         email,
         newPassword,
       },
-      getRequestConfig(accessToken, null, sourceIp)
+      getRequestConfig(
+        accessToken,
+        [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
+        sourceIp
+      )
     );
+    return createApiResponse(response, [HTTP_STATUS_CODES.NO_CONTENT]);
   };
 
   return {

--- a/src/components/change-password/tests/change-password-controller.test.ts
+++ b/src/components/change-password/tests/change-password-controller.test.ts
@@ -38,7 +38,7 @@ describe("change password controller", () => {
   describe("changePasswordPost", () => {
     it("should redirect to /password-updated-confirmation page", async () => {
       const fakeService: ChangePasswordServiceInterface = {
-        updatePassword: sandbox.fake(),
+        updatePassword: sandbox.fake.returns({ success: true }),
       };
 
       req.session.user.tokens = { accessToken: "token" };

--- a/src/components/change-password/tests/change-password-integration.test.ts
+++ b/src/components/change-password/tests/change-password-integration.test.ts
@@ -184,6 +184,30 @@ describe("Integration:: change password", () => {
       .expect(400, done);
   });
 
+  it("should return error when new password is the same as existing password", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.UPDATE_PASSWORD)
+      .once()
+      .reply(400, { code: 1024 });
+
+    request(app)
+      .post(PATH_DATA.CHANGE_PASSWORD.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "p@ssw0rd-123",
+        "confirm-password": "p@ssw0rd-123",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains(
+          "Your account is already using that password. Enter a different password"
+        );
+      })
+      .expect(400, done);
+  });
+
   it("should redirect to enter phone number when valid password entered", (done) => {
     nock(baseApi).post(API_ENDPOINTS.UPDATE_PASSWORD).once().reply(204);
 

--- a/src/components/change-password/tests/change-password-integration.test.ts
+++ b/src/components/change-password/tests/change-password-integration.test.ts
@@ -208,6 +208,30 @@ describe("Integration:: change password", () => {
       .expect(400, done);
   });
 
+  it("should throw error when 400 is returned from API", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.UPDATE_PASSWORD)
+      .once()
+      .reply(400, { code: 1000 });
+
+    request(app)
+      .post(PATH_DATA.CHANGE_PASSWORD.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "p@ssw0rd-123",
+        "confirm-password": "p@ssw0rd-123",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($(".govuk-heading-l").text()).to.contains(
+          "Sorry, there is a problem with the service"
+        );
+      })
+      .expect(500, done);
+  });
+
   it("should redirect to enter phone number when valid password entered", (done) => {
     nock(baseApi).post(API_ENDPOINTS.UPDATE_PASSWORD).once().reply(204);
 

--- a/src/components/change-password/types.ts
+++ b/src/components/change-password/types.ts
@@ -1,8 +1,10 @@
+import { ApiResponseResult } from "../../utils/types";
+
 export interface ChangePasswordServiceInterface {
   updatePassword: (
     accessToken: string,
     email: string,
     newPassword: string,
     sourceIp: string
-  ) => Promise<void>;
+  ) => Promise<ApiResponseResult>;
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -210,6 +210,7 @@
           "minLength": "Your password must be at least 8 characters long and must include a number",
           "maxLength": "Your password must be less than 256 characters",
           "commonPassword": "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers.",
+          "samePassword": "Your account is already using that password. Enter a different password",
           "alphaNumeric": "Your password must be at least 8 characters long and must include a number"
         }
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -210,6 +210,7 @@
           "minLength": "Your password must be at least 8 characters long and must include a number",
           "maxLength": "Your password must be less than 256 characters",
           "commonPassword": "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers.",
+          "samePassword": "Your account is already using that password. Enter a different password",
           "alphaNumeric": "Your password must be at least 8 characters long and must include a number"
         }
       },

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,3 +7,11 @@ export class ApiError extends Error {
     this.status = status;
   }
 }
+
+export class BadRequestError extends Error {
+  private status: number;
+  constructor(message: string, code: number | string) {
+    super(`${code}:${message}`);
+    this.status = 400;
+  }
+}

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -2,9 +2,12 @@ import axios, {
   AxiosInstance,
   AxiosRequestConfig,
   AxiosError,
+  AxiosResponse,
   AxiosRequestHeaders,
 } from "axios";
+import { ApiResponseResult } from "../utils/types";
 import { getApiBaseUrl } from "../config";
+import { HTTP_STATUS_CODES } from "../app.constants";
 import { ApiError } from "./errors";
 
 const headers: AxiosRequestHeaders = {
@@ -13,6 +16,17 @@ const headers: AxiosRequestHeaders = {
   "Access-Control-Allow-Credentials": "true",
   "X-Requested-With": "XMLHttpRequest",
 };
+
+export function createApiResponse(
+  response: AxiosResponse,
+  status: number[] = [HTTP_STATUS_CODES.OK, HTTP_STATUS_CODES.NO_CONTENT]
+): ApiResponseResult {
+  return {
+    success: status.includes(response.status),
+    code: response.data.code,
+    message: response.data.message,
+  };
+}
 
 export function getRequestConfig(
   token: string,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -19,6 +19,19 @@ export interface ClientAssertionServiceInterface {
   ) => Promise<string>;
 }
 
+export interface ApiResponse {
+  code?: number;
+  message?: string;
+  email?: string;
+  data: any;
+}
+
+export interface ApiResponseResult {
+  success: boolean;
+  code?: number;
+  message?: string;
+}
+
 export interface Error {
   text: string;
   href: string;


### PR DESCRIPTION
## What?

- When a user tries attempts to change their password using their existing password the api will return an error code. When this error code is returned to the user we need to present the correct error message to the user.

## Why?

- Because a user shouldn't be able to change their password to their existing password.

