### PR TITLE
GOVSI-1141: log session id on am frontend and pass to apis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build: .
     ports:
       - 6001:6001
-      - 9230:9230
+      - 9240:9230
     volumes:
       - ./:/app
     environment:

--- a/src/components/change-email/change-email-controller.ts
+++ b/src/components/change-email/change-email-controller.ts
@@ -41,6 +41,7 @@ export function changeEmailPost(
       newEmailAddress,
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip,
+      res.locals.sessionId,
       res.locals.persistentSessionId
     );
 

--- a/src/components/change-email/types.ts
+++ b/src/components/change-email/types.ts
@@ -4,6 +4,7 @@ export interface ChangeEmailServiceInterface {
     email: string,
     notificationType: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ) => Promise<boolean>;
 }

--- a/src/components/change-password/change-password-controller.ts
+++ b/src/components/change-password/change-password-controller.ts
@@ -29,6 +29,7 @@ export function changePasswordPost(
       email,
       newPassword,
       req.ip,
+      res.locals.sessionId,
       res.locals.persistentSessionId
     );
 

--- a/src/components/change-password/change-password-service.ts
+++ b/src/components/change-password/change-password-service.ts
@@ -16,6 +16,7 @@ export function changePasswordService(
     email: string,
     newPassword: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ): Promise<ApiResponseResult> {
     const response = await axios.client.post<ApiResponse>(
@@ -28,6 +29,7 @@ export function changePasswordService(
         accessToken,
         [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
         sourceIp,
+        sessionId,
         persistentSessionId
       )
     );

--- a/src/components/change-password/types.ts
+++ b/src/components/change-password/types.ts
@@ -6,6 +6,7 @@ export interface ChangePasswordServiceInterface {
     email: string,
     newPassword: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -40,6 +40,7 @@ export function changePhoneNumberPost(
       email,
       newPhoneNumber,
       req.ip,
+      res.locals.sessionId,
       res.locals.persistentSessionId
     );
 

--- a/src/components/change-phone-number/change-phone-number-service.ts
+++ b/src/components/change-phone-number/change-phone-number-service.ts
@@ -10,6 +10,7 @@ export function changePhoneNumberService(
     email: string,
     phoneNumber: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ): Promise<void> {
     await axios.client.post<void>(
@@ -19,7 +20,13 @@ export function changePhoneNumberService(
         phoneNumber,
         notificationType: NOTIFICATION_TYPE.VERIFY_PHONE_NUMBER,
       },
-      getRequestConfig(accessToken, null, sourceIp, persistentSessionId)
+      getRequestConfig(
+        accessToken,
+        null,
+        sourceIp,
+        sessionId,
+        persistentSessionId
+      )
     );
   };
 

--- a/src/components/change-phone-number/types.ts
+++ b/src/components/change-phone-number/types.ts
@@ -4,6 +4,7 @@ export interface ChangePhoneNumberServiceInterface {
     email: string,
     phoneNumber: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ) => Promise<void>;
 }

--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -35,6 +35,7 @@ export function checkYourEmailPost(
       newEmailAddress,
       code,
       req.ip,
+      res.locals.sessionId,
       res.locals.persistentSessionId
     );
 

--- a/src/components/check-your-email/check-your-email-service.ts
+++ b/src/components/check-your-email/check-your-email-service.ts
@@ -12,6 +12,7 @@ export function checkYourEmailService(
     replacementEmailAddress: string,
     code: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ): Promise<boolean> {
     const { status }: AxiosResponse = await axios.client.post(
@@ -25,6 +26,7 @@ export function checkYourEmailService(
         accessToken,
         [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
         sourceIp,
+        sessionId,
         persistentSessionId
       )
     );

--- a/src/components/check-your-email/types.ts
+++ b/src/components/check-your-email/types.ts
@@ -5,6 +5,7 @@ export interface CheckYourEmailServiceInterface {
     replacementEmailAddress: string,
     code: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ) => Promise<boolean>;
 }

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -32,6 +32,7 @@ export function checkYourPhonePost(
       newPhoneNumber,
       code,
       req.ip,
+      res.locals.sessionId,
       res.locals.persistentSessionId
     );
 

--- a/src/components/check-your-phone/check-your-phone-service.ts
+++ b/src/components/check-your-phone/check-your-phone-service.ts
@@ -11,6 +11,7 @@ export function checkYourPhoneService(
     phoneNumber: string,
     otp: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ): Promise<boolean> {
     const { status } = await axios.client.post<void>(
@@ -24,6 +25,7 @@ export function checkYourPhoneService(
         accessToken,
         [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
         sourceIp,
+        sessionId,
         persistentSessionId
       )
     );

--- a/src/components/check-your-phone/types.ts
+++ b/src/components/check-your-phone/types.ts
@@ -5,6 +5,7 @@ export interface CheckYourPhoneServiceInterface {
     phoneNumber: string,
     otp: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ) => Promise<boolean>;
 }

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -24,6 +24,7 @@ export function deleteAccountPost(
       accessToken,
       email,
       req.ip,
+      res.locals.sessionId,
       res.locals.persistentSessionId
     );
     await publishingService

--- a/src/components/delete-account/delete-account-service.ts
+++ b/src/components/delete-account/delete-account-service.ts
@@ -10,6 +10,7 @@ export function deleteAccountService(
     token: string,
     email: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ): Promise<void> {
     await axios.client.post<void>(
@@ -17,7 +18,7 @@ export function deleteAccountService(
       {
         email: email,
       },
-      getRequestConfig(token, null, sourceIp, persistentSessionId)
+      getRequestConfig(token, null, sourceIp, sessionId, persistentSessionId)
     );
   };
 

--- a/src/components/delete-account/types.ts
+++ b/src/components/delete-account/types.ts
@@ -3,6 +3,7 @@ export interface DeleteAccountServiceInterface {
     token: string,
     email: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ) => Promise<void>;
 }

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -43,6 +43,7 @@ export function enterPasswordPost(
       email,
       req.body["password"],
       req.ip,
+      res.locals.sessionId,
       res.locals.persistentSessionId
     );
 

--- a/src/components/enter-password/enter-password-service.ts
+++ b/src/components/enter-password/enter-password-service.ts
@@ -10,6 +10,7 @@ export function enterPasswordService(
     emailAddress: string,
     password: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ): Promise<boolean> {
     const { status } = await axios.client.post<void>(
@@ -26,6 +27,7 @@ export function enterPasswordService(
           HTTP_STATUS_CODES.UNAUTHORIZED,
         ],
         sourceIp,
+        sessionId,
         persistentSessionId
       )
     );

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -4,6 +4,7 @@ export interface EnterPasswordServiceInterface {
     email: string,
     password: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ) => Promise<boolean>;
 }

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -21,6 +21,11 @@ export function setLocalVarsMiddleware(
   res.locals.analyticsCookieDomain = getAnalyticsCookieDomain();
   res.locals.cookiesAndFeedbackUrl = getCookiesAndFeedbackLink();
   res.locals.govAccountsUrl = formatYourAccountUrl(req, getYourAccountUrl());
+  if (req.cookies && req.cookies.gs) {
+    const ids = xss(req.cookies["gs"]).split(".");
+    res.locals.sessionId = ids[0];
+    res.locals.clientSessionId = ids[1];
+  }
   if (req.cookies && req.cookies["di-persistent-session-id"]) {
     res.locals.persistentSessionId = xss(
       req.cookies["di-persistent-session-id"]

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -32,7 +32,8 @@ export function getRequestConfig(
   token: string,
   validationStatues?: number[],
   sourceIp?: string,
-  persistentSessionId?: string
+  persistentSessionId?: string,
+  sessionId?: string
 ): AxiosRequestConfig {
   const config: AxiosRequestConfig = {
     headers: {
@@ -53,6 +54,10 @@ export function getRequestConfig(
 
   if (persistentSessionId) {
     config.headers["di-persistent-session-id"] = persistentSessionId;
+  }
+
+  if (sessionId) {
+    config.headers["Session-Id"] = sessionId;
   }
 
   return config;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,18 +11,32 @@ const logger = pino({
         id: req.id,
         method: req.method,
         url: req.url,
+        from: getRefererFrom(req.headers.referer),
       };
     },
     res: (res) => {
       return {
-        id: res.id,
-        method: res.method,
-        url: res.url,
-        status: res.status,
+        status: res.statusCode,
+        sessionId: res.locals.sessionId,
+        clientSessionId: res.locals.clientSessionId,
+        persistentSessionId: res.locals.persistentSessionId,
       };
     },
   },
 });
+
+export function getRefererFrom(referer: string): string {
+  if (referer) {
+    try {
+      const refererUrl = new URL(referer);
+      return refererUrl.pathname + refererUrl.search;
+    } catch (error) {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+}
 
 const loggerMiddleware = PinoHttp({
   logger,

--- a/test/utils/logger.test.ts
+++ b/test/utils/logger.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { getRefererFrom } from "../../src/utils/logger";
+
+describe("logger", () => {
+  describe("getRefererFrom", () => {
+    it("should return path from a url", () => {
+      expect(getRefererFrom("http://localhost:8080/hello")).to.equal("/hello");
+    });
+
+    it("should return path from a gov.uk url", () => {
+      expect(getRefererFrom("http://gov.uk/hello")).to.equal("/hello");
+    });
+
+    it("should return path from an https gov.uk url", () => {
+      expect(getRefererFrom("https://gov.uk/hello")).to.equal("/hello");
+    });
+
+    it("should return path from a url without port", () => {
+      expect(getRefererFrom("http://localhost/hello")).to.equal("/hello");
+    });
+
+    it("should return a longer path from a url", () => {
+      expect(
+        getRefererFrom("http://localhost:8080/hello/good/morning")
+      ).to.equal("/hello/good/morning");
+    });
+
+    it("should return path and query from a url", () => {
+      expect(getRefererFrom("http://localhost:8080/hello?world=true")).to.equal(
+        "/hello?world=true"
+      );
+    });
+
+    it("should return query only from a url", () => {
+      expect(getRefererFrom("http://localhost:8080?world=true")).to.equal(
+        "/?world=true"
+      );
+    });
+
+    it("should return a longer path and query from a url", () => {
+      expect(
+        getRefererFrom("http://localhost:8080/hello/good/morning?world=true")
+      ).to.equal("/hello/good/morning?world=true");
+    });
+
+    it("should return a longer path and two query params from a url", () => {
+      expect(
+        getRefererFrom(
+          "http://localhost:8080/hello/good/morning?world=true&morning=good"
+        )
+      ).to.equal("/hello/good/morning?world=true&morning=good");
+    });
+
+    it("should return empty path from a url", () => {
+      expect(getRefererFrom("http://localhost:8080")).to.equal("/");
+    });
+
+    it("should return empty path from a url ending with /", () => {
+      expect(getRefererFrom("http://localhost:8080/")).to.equal("/");
+    });
+
+    it("should return undefined for null url", () => {
+      expect(getRefererFrom(null)).to.equal(undefined);
+    });
+
+    it("should return undefined for undefined url", () => {
+      expect(getRefererFrom(undefined)).to.equal(undefined);
+    });
+
+    it("should return undefined for invalid url", () => {
+      expect(getRefererFrom("hello")).to.equal(undefined);
+    });
+
+    it("should return undefined for invalid protocol", () => {
+      expect(getRefererFrom("https;//hello")).to.equal(undefined);
+    });
+
+    it("should return undefined for invalid port", () => {
+      expect(getRefererFrom("https://localhost:hello")).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
## What?

- Log session id on am frontend and pass to apis.
- Tweak am frontend response logging to remove unavailable fields.
- Add 'from' field to request logging to bring into line with frontend.
- Change local node debug port to stop clash with frontend.

## Why?

- Ability to view a single session across both frontend and account management.
- Some fields being logged in the am frontend response were not actually available so were never being logged.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
