### PR TITLE
AUTH-1273: update config for redis and kms to run on fargate

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,7 @@ applications:
       - nodejs_buildpack
     env:
       NODE_ENV: "production"
+      APP_ENV: ((environment_name))
       API_BASE_URL: ((api_base_url))
       AM_API_BASE_URL: ((am_api_base_url))
       SESSION_EXPIRY: ((session_expiry))

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -4,9 +4,9 @@ import { DeleteAccountServiceInterface } from "./types";
 import { deleteAccountService } from "./delete-account-service";
 import { PATH_DATA } from "../../app.constants";
 import { getNextState } from "../../utils/state-machine";
-import CF_CONFIG from "../../config/cf";
 import { GovUkPublishingServiceInterface } from "../common/gov-uk-publishing/types";
 import { govUkPublishingService } from "../common/gov-uk-publishing/gov-uk-publishing-service";
+import { getBaseUrl } from "../../config";
 
 export function deleteAccountGet(req: Request, res: Response): void {
   res.render("delete-account/index.njk");
@@ -46,7 +46,7 @@ export function deleteAccountPost(
     const logoutUrl = req.oidc.endSessionUrl({
       id_token_hint: req.session.user.tokens.idToken,
       post_logout_redirect_uri:
-        CF_CONFIG.url + PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url,
+        getBaseUrl() + PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url,
     });
 
     req.session.destroy();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,9 @@
+import CF_CONFIG from "./config/cf";
+
+const AWS = require("aws-sdk");
+
+const SSM = new AWS.SSM();
+
 export function getLogLevel(): string {
   return process.env.LOGS_LEVEL || "debug";
 }
@@ -24,6 +30,10 @@ export function getOIDCClientScopes(): string {
 
 export function getNodeEnv(): string {
   return process.env.NODE_ENV || "development";
+}
+
+export function getAppEnv(): string {
+  return process.env.APP_ENV || "local";
 }
 
 export function getGtmId(): string {
@@ -54,6 +64,14 @@ export function getRedisHost(): string {
   return process.env.REDIS_HOST ?? "redis";
 }
 
+export function getRedisPort(): number {
+  return Number(process.env.REDIS_PORT) ?? 6379;
+}
+
+export function getRedisPassword(): any {
+  return getParameter(getAppEnv() + "-redis-password");
+}
+
 export function getAuthFrontEndUrl(): string {
   return "https://" + process.env.AUTH_FRONTEND_URL;
 }
@@ -65,3 +83,32 @@ export function getAnalyticsCookieDomain(): string {
 export function getCookiesAndFeedbackLink(): string {
   return process.env.COOKIES_AND_FEEDBACK_URL;
 }
+
+export function isFargate(): boolean {
+  return false;
+}
+
+export function getBaseUrl(): string {
+  if (isFargate()) {
+    return "?";
+  } else {
+    return CF_CONFIG.url;
+  }
+}
+
+export function getAwsRegion(): string {
+  return "eu-west-2";
+}
+
+export function getKmsKeyId(): string {
+  return process.env.KMS_KEY_ID;
+}
+
+const getParameter = async (parameterName: string) => {
+  const result = await SSM.getParameter({
+    Name: `${parameterName}`,
+    WithDecryption: true,
+  }).promise();
+
+  return result.Parameter.Value;
+};

--- a/src/config/aws.ts
+++ b/src/config/aws.ts
@@ -1,6 +1,11 @@
 import AWS from "aws-sdk";
 import CF_CONFIG from "./cf";
-import { getLocalStackBaseUrl } from "../config";
+import {
+  getAwsRegion,
+  getKmsKeyId,
+  getLocalStackBaseUrl,
+  isFargate,
+} from "../config";
 
 //refer to seed.yaml
 const LOCAL_KEY_ID = "ff275b92-0def-4dfc-b0f6-87c96b26c6c7";
@@ -31,8 +36,15 @@ function getLocalStackConfig() {
 }
 
 export function getKMSConfig(): KmsConfig {
+  if (isFargate()) {
+    return {
+      awsConfig: {
+        region: getAwsRegion(),
+      },
+      kmsKeyId: getKmsKeyId(),
+    };
+  }
   const config = getLocalStackConfig();
-
   if (CF_CONFIG.isLocal) {
     return config;
   }

--- a/src/config/oidc.ts
+++ b/src/config/oidc.ts
@@ -1,14 +1,16 @@
 import { OIDCConfig } from "../types";
 import CF_CONFIG from "./cf";
 import {
+  getBaseUrl,
   getOIDCApiDiscoveryUrl,
   getOIDCClientId,
   getOIDCClientScopes,
+  isFargate,
 } from "../config";
 
 export function getOIDCConfig(): OIDCConfig {
-  const callBackUrl = CF_CONFIG.url + "/auth/callback";
-  if (CF_CONFIG.isLocal) {
+  const callBackUrl = getBaseUrl() + "/auth/callback";
+  if (CF_CONFIG.isLocal || isFargate()) {
     return {
       client_id: getOIDCClientId(),
       idp_url: getOIDCApiDiscoveryUrl(),

--- a/src/config/session.ts
+++ b/src/config/session.ts
@@ -2,7 +2,12 @@ import redis, { ClientOpts } from "redis";
 import connect_redis, { RedisStore } from "connect-redis";
 import session from "express-session";
 import CF_CONFIG from "./cf";
-import { getRedisHost } from "../config";
+import {
+  getRedisHost,
+  getRedisPassword,
+  getRedisPort,
+  isFargate,
+} from "../config";
 const RedisStore = connect_redis(session);
 
 export interface RedisConfigCf {
@@ -15,7 +20,13 @@ export interface RedisConfigCf {
 
 export function getSessionStore(): RedisStore {
   let config: ClientOpts;
-  if (CF_CONFIG.isLocal) {
+  if (isFargate()) {
+    config = {
+      host: getRedisHost(),
+      port: getRedisPort(),
+      password: getRedisPassword(),
+    };
+  } else if (CF_CONFIG.isLocal) {
     config = {
       host: getRedisHost(),
     };


### PR DESCRIPTION
## What?

Update Account Management to support running under Fargate.

- Redis config.
- KMS config. 

## Why?

Configuration and accessing AWS is different under Fargate compared to Paas.
