### PR TITLE
AUTH-1273: create separate docker image for fargate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,20 @@ FROM node:16.8.0-alpine
 ENV NODE_ENV "development"
 ENV PORT 6001
 
-VOLUME ["/app"]
 WORKDIR /app
+
+COPY package.json ./
+COPY yarn.lock ./
+COPY tsconfig.json ./
+
+RUN yarn clean && yarn install
+
+COPY ./src ./src
+COPY ./static ./static
+COPY ./@types ./@types
+
+RUN yarn build
 
 EXPOSE $PORT
 
-CMD yarn install && yarn copy-assets && yarn dev
-
+CMD yarn run start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
       - 6379:6379
 
   di-auth-account-management-frontend:
-    build: .
+    build:
+      context: .
+      dockerfile: local.Dockerfile
     ports:
       - 6001:6001
       - 9240:9230

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,0 +1,12 @@
+FROM node:16.8.0-alpine
+
+ENV NODE_ENV "development"
+ENV PORT 6001
+
+VOLUME ["/app"]
+WORKDIR /app
+
+EXPOSE $PORT
+
+CMD yarn install && yarn copy-assets && yarn dev
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "yarn build-sass && yarn build-ts && yarn minfiy-build-js && yarn copy-assets",
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/style.css --style compressed",
     "clean": "rm -rf dist node_modules logs.json",
-    "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && cp node_modules/govuk-frontend/govuk/all.js src/assets/javascript && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts",
+    "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts -e **/all.js && cp node_modules/govuk-frontend/govuk/all.js dist/public/scripts",
     "dev": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run watch-node\"",
     "dummy-server": "node dev-app.js",
     "depcheck": "depcheck",


### PR DESCRIPTION
## What?

Create separate docker image for fargate.

- Rename existing local image and update docker-compose.yml to use it.
- Add a new dockerfile to run the application in fargate.  This image needs all files locally as it cannot rely on a mounted volume.
- Use 'cp' instead of 'copyfiles' in one place in package.json as copyfiles was hanging when building and/or running the docker image.

## Why?

A separate image is needed to run in fargate as we are currently using a CF node buildpack rather than a docker image.  The existing local image could not be run in fargate as-is. 