### PR TITLE
AUTH-1168 - Set ConsentRequired to false for Account Management

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -75,6 +75,9 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     },
     CookieConsentShared = {
       N = "1"
+    },
+    ConsentRequired = {
+      N = "0"
     }
   })
 }


### PR DESCRIPTION
## What?

 - Explicitly set ConsentRequired to false for Account Management

## Why?

- Although by default ConsentRequired would be false we should be explicit where possible. 
- Account Management users do not require to view the consent page. We were previously using the InternalService flag for this but we are now transitioning to a broader named flag to manage this as it will not just be internal service users who should not see the consent page.

