### PR TITLE
BAU - Use Multistage docker builds to reduce fargate docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
-FROM node:16.13.0-alpine
+FROM node:16.13.0-alpine as builder
+WORKDIR /app
+COPY package.json ./
+COPY yarn.lock ./
+COPY tsconfig.json ./
+COPY ./src ./src
+COPY ./static ./static
+COPY ./@types ./@types
+RUN yarn install --production=true
+
+FROM node:16.13.0-alpine as final
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/node_modules/ node_modules
 
 ENV NODE_ENV "development"
 ENV PORT 6001
 
-WORKDIR /app
-
-COPY package.json ./
-COPY yarn.lock ./
-COPY tsconfig.json ./
-
-RUN yarn clean && yarn install
-
-COPY ./src ./src
-COPY ./static ./static
-COPY ./@types ./@types
-
-RUN yarn build
-
 EXPOSE $PORT
 
-CMD yarn run start
+CMD yarn start


### PR DESCRIPTION
## What?

- Use Multistage docker builds to reduce fargate docker image size

## Why?

- By using multistage docker builds we can reduce the size of the docker image in ECR from 179mb to 61mb.
