### PR TITLE
AUTH-1277: add healthcheck endpoint to account management application

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -69,6 +69,7 @@ export const PATH_DATA: {
   SESSION_EXPIRED: { url: "/session-expired" },
   SIGN_OUT: { url: "/sign-out" },
   START: { url: "/" },
+  HEALTHCHECK: { url: "/healthcheck" },
 };
 
 export const API_ENDPOINTS = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,7 @@ import { checkYourPhoneRouter } from "./components/check-your-phone/check-your-p
 import { noCacheMiddleware } from "./middleware/no-cache-middleware";
 import { sessionExpiredRouter } from "./components/session-expired/session-expired-routes";
 import { setLocalVarsMiddleware } from "./middleware/set-local-vars-middleware";
+import { healthcheckRouter } from "./components/healthcheck/healthcheck-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -59,6 +60,7 @@ function registerRoutes(app: express.Application) {
   app.use(deleteAccountRouter);
   app.use(checkYourPhoneRouter);
   app.use(sessionExpiredRouter);
+  app.use(healthcheckRouter);
 }
 
 function createApp(): express.Application {

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,7 +60,6 @@ function registerRoutes(app: express.Application) {
   app.use(deleteAccountRouter);
   app.use(checkYourPhoneRouter);
   app.use(sessionExpiredRouter);
-  app.use(healthcheckRouter);
 }
 
 function createApp(): express.Application {
@@ -114,6 +113,7 @@ function createApp(): express.Application {
     })
   );
 
+  app.use(healthcheckRouter);
   app.use(authMiddleware(getOIDCConfig()));
   app.use(csurf({ cookie: getCSRFCookieOptions(isProduction) }));
 

--- a/src/components/healthcheck/healthcheck-controller.ts
+++ b/src/components/healthcheck/healthcheck-controller.ts
@@ -1,0 +1,6 @@
+import { Request, Response } from "express";
+import { HTTP_STATUS_CODES } from "../../app.constants";
+
+export function healthcheckGet(req: Request, res: Response): void {
+  res.status(HTTP_STATUS_CODES.OK).send("OK");
+}

--- a/src/components/healthcheck/healthcheck-routes.ts
+++ b/src/components/healthcheck/healthcheck-routes.ts
@@ -1,0 +1,10 @@
+import { PATH_DATA } from "../../app.constants";
+
+import * as express from "express";
+import { healthcheckGet } from "./healthcheck-controller";
+
+const router = express.Router();
+
+router.get(PATH_DATA.HEALTHCHECK.url, healthcheckGet);
+
+export { router as healthcheckRouter };

--- a/src/components/healthcheck/tests/healthcheck-controller.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-controller.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { healthcheckGet } from "../healthcheck-controller";
+import { HTTP_STATUS_CODES } from "../../../app.constants";
+
+describe("healthcheck controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+    };
+    res = {
+      status: sandbox.stub().returnsThis(),
+      send: sandbox.fake(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("healthcheckGet", () => {
+    it("should return 200", () => {
+      healthcheckGet(req as Request, res as Response);
+
+      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.OK);
+    });
+  });
+});

--- a/src/components/healthcheck/tests/healthcheck-integration.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-integration.test.ts
@@ -1,0 +1,23 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import { PATH_DATA } from "../../../app.constants";
+
+describe("Integration::healthcheck", () => {
+  let sandbox: sinon.SinonSandbox;
+  let app: any;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    app = require("../../../app").createApp();
+  });
+
+  after(() => {
+    sandbox.restore();
+    app = undefined;
+  });
+
+  it("healthcheck should return 200 OK", (done) => {
+    request(app).get(PATH_DATA.HEALTHCHECK.url).expect(200, done);
+  });
+});

--- a/src/components/healthcheck/tests/healthcheck-integration.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-integration.test.ts
@@ -2,12 +2,15 @@ import request from "supertest";
 import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { PATH_DATA } from "../../../app.constants";
+import decache from "decache";
 
 describe("Integration::healthcheck", () => {
   let sandbox: sinon.SinonSandbox;
   let app: any;
 
   before(() => {
+    decache("../../../app");
+    decache("../../../middleware/requires-auth-middleware");
     sandbox = sinon.createSandbox();
     app = require("../../../app").createApp();
   });


### PR DESCRIPTION
## What?

Add healthcheck endpoint to account management application.
The endpoint returns a simple '200 OK'

## Why?

ALB and Fargate requires a healthcheck endpoint to know whether the app has started.

