### PR TITLE
AUTH-1277: update dockerfile to use yarn build rather than production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ COPY tsconfig.json ./
 COPY ./src ./src
 COPY ./static ./static
 COPY ./@types ./@types
-RUN yarn install --production=true
+RUN yarn install && yarn build
 
 FROM node:16.13.0-alpine as final
 WORKDIR /app
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/node_modules/ node_modules
+COPY --from=builder /app/dist/ dist
 
 ENV NODE_ENV "development"
 ENV PORT 6001


### PR DESCRIPTION
## What?

Update dockerfile to use yarn build rather than production

## Why?

Build is currently being used in PaaS rather than production so this reflects the live application.
Further configuration tweaks will be needed to make the production config work.