### PR TITLE
AUTH-1273: read redis configuration from ssm for ecs fargate

### DIFF
--- a/src/components/change-email/tests/change-email-integration.test.ts
+++ b/src/components/change-email/tests/change-email-integration.test.ts
@@ -15,7 +15,7 @@ describe("Integration:: change email", () => {
   let baseApi: string;
   const TEST_SUBJECT_ID = "jkduasd";
 
-  before((done) => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
@@ -53,17 +53,16 @@ describe("Integration:: change email", () => {
       });
     });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 
     request(app)
       .get(PATH_DATA.CHANGE_EMAIL.url)
-      .expect((res) => {
+      .end((err, res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
-      })
-      .expect(200, done);
+      });
   });
 
   beforeEach(() => {

--- a/src/components/change-password/change-password-routes.ts
+++ b/src/components/change-password/change-password-routes.ts
@@ -8,6 +8,7 @@ import { validateChangePasswordRequest } from "./change-password-validation";
 import { asyncHandler } from "../../utils/async";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
+import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
 
 const router = express.Router();
 
@@ -22,6 +23,7 @@ router.post(
   PATH_DATA.CHANGE_PASSWORD.url,
   requiresAuthMiddleware,
   validateChangePasswordRequest(),
+  refreshTokenMiddleware(),
   asyncHandler(changePasswordPost())
 );
 

--- a/src/components/change-password/tests/change-password-integration.test.ts
+++ b/src/components/change-password/tests/change-password-integration.test.ts
@@ -14,7 +14,7 @@ describe("Integration:: change password", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
@@ -51,7 +51,7 @@ describe("Integration:: change password", () => {
       });
     });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 
     request(app)

--- a/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
@@ -14,7 +14,7 @@ describe("Integration:: change phone number", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
@@ -51,7 +51,7 @@ describe("Integration:: change phone number", () => {
       });
     });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 
     request(app)

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -16,7 +16,7 @@ describe("Integration:: check your email", () => {
   let govUkPublishingBaseApi: string;
   const TEST_SUBJECT_ID = "jkduasd";
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
@@ -54,7 +54,7 @@ describe("Integration:: check your email", () => {
       });
     });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
     govUkPublishingBaseApi = process.env.GOV_ACCOUNTS_PUBLISHING_API_URL;
 

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -14,7 +14,7 @@ describe("Integration:: check your phone", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
@@ -51,7 +51,7 @@ describe("Integration:: check your phone", () => {
       });
     });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 
     request(app)

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -18,7 +18,7 @@ describe("Integration:: delete account", () => {
   const idToken = "Idtoken";
   const TEST_SUBJECT_ID = "sub";
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
@@ -64,7 +64,7 @@ describe("Integration:: delete account", () => {
       });
     });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
 
     baseApi = process.env.AM_API_BASE_URL;
     govUkPublishingBaseApi = process.env.GOV_ACCOUNTS_PUBLISHING_API_URL;

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -16,7 +16,7 @@ describe("Integration::enter password", () => {
 
   const ENDPOINT = PATH_DATA.ENTER_PASSWORD.url;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
@@ -59,7 +59,7 @@ describe("Integration::enter password", () => {
       });
     });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 
     request(app)

--- a/src/components/healthcheck/tests/healthcheck-integration.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-integration.test.ts
@@ -8,11 +8,11 @@ describe("Integration::healthcheck", () => {
   let sandbox: sinon.SinonSandbox;
   let app: any;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     sandbox = sinon.createSandbox();
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
   });
 
   after(() => {

--- a/src/components/manage-your-account/tests/manage-your-account-integration.test.ts
+++ b/src/components/manage-your-account/tests/manage-your-account-integration.test.ts
@@ -7,7 +7,7 @@ import decache from "decache";
 describe("Integration:: manage your account", () => {
   let sandbox: sinon.SinonSandbox;
   let app: any;
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
@@ -36,7 +36,7 @@ describe("Integration:: manage your account", () => {
       });
     });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
   });
 
   beforeEach(() => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,19 +1,17 @@
-import http from "http";
 import { createApp } from "./app";
 import { logger } from "./utils/logger";
 
-const app = createApp();
 const port: number | string = process.env.PORT || 6001;
 
-const server = http.createServer(app);
-
-server.setTimeout(300000);
-
-server
-  .listen(port, () => {
-    logger.info(`Server listening on port ${port}`);
-    app.emit("appStarted");
-  })
-  .on("error", (error: Error) => {
-    logger.error(`Unable to start server because of ${error.message}`);
-  });
+(async () => {
+  const app = await createApp();
+  app
+    .listen(port, () => {
+      logger.info(`Server listening on port ${port}`);
+    })
+    .on("error", (error: Error) => {
+      logger.error(`Unable to start server because of ${error.message}`);
+    });
+})().catch((ex) => {
+  logger.error(`Server failed to create app ${ex.message}`);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,12 @@ export type ValidationChainFunc = (
       next: express.NextFunction
     ) => any)
 )[];
+
+export interface RedisConfig {
+  host: string;
+  port: string;
+  password: string;
+  name?: string;
+  uri?: string;
+  tls?: boolean;
+}

--- a/src/utils/ssm.ts
+++ b/src/utils/ssm.ts
@@ -1,0 +1,3 @@
+const AWS = require("aws-sdk");
+
+export default new AWS.SSM();


### PR DESCRIPTION
## What?

Read Redis configuration from SSM for ECS Fargate.

## Why?

AM currently runs on PaaS and retrieves Redis connection details from PaaS services.  This option is not available when running on ECS Fargate.

Some Redis connection details are secret so we decided to put them in AWS SSM Parameter store.  This PR reads these parameters from SSM when running under Fargate so that the app can connect to Redis.
 
## Related PRs
