### PR TITLE
AUTH-1276: Create frontend Redis for Fargate

### DIFF
--- a/ci/terraform/account-management-kms.tf
+++ b/ci/terraform/account-management-kms.tf
@@ -3,6 +3,8 @@ resource "aws_kms_key" "account_management_jwt_key" {
   deletion_window_in_days  = 30
   key_usage                = "SIGN_VERIFY"
   customer_master_key_spec = "RSA_2048"
+
+  tags = local.default_tags
 }
 
 resource "aws_kms_alias" "account_management_jwt_alias" {
@@ -31,10 +33,14 @@ resource "aws_iam_policy" "account_management_jwt_lambda_kms_policy" {
   description = "IAM policy for managing KMS connection for account management application"
 
   policy = data.aws_iam_policy_document.account_management_jwt_kms_policy_document.json
+
+  tags = local.default_tags
 }
 
 resource "aws_iam_user" "account_management_app" {
   name = "${var.environment}-account-management-application"
+
+  tags = local.default_tags
 }
 
 resource "aws_iam_user_policy_attachment" "account_management_app_kms_policy" {
@@ -66,6 +72,8 @@ data "aws_iam_policy_document" "account_management_app_role_assume_policy" {
 
 resource "aws_iam_role" "account_management_app_role" {
   assume_role_policy = data.aws_iam_policy_document.account_management_app_role_assume_policy.json
+
+  tags = local.default_tags
 }
 
 resource "aws_iam_role_policy_attachment" "account_management_app_kms" {

--- a/ci/terraform/alerts.tf
+++ b/ci/terraform/alerts.tf
@@ -1,0 +1,3 @@
+data "aws_sns_topic" "slack_events" {
+  name = "${var.environment}-slack-events"
+}

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,4 +1,4 @@
-redis_service_plan = "tiny-ha-5_x"
-environment        = "build"
-your_account_url   = ""
+redis_service_plan  = "tiny-ha-5_x"
+environment         = "build"
+your_account_url    = ""
 common_state_bucket = "digital-identity-dev-tfstate"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,3 +1,4 @@
 redis_service_plan = "tiny-ha-5_x"
 environment        = "build"
 your_account_url   = ""
+common_state_bucket = "digital-identity-dev-tfstate"

--- a/ci/terraform/core.tf
+++ b/ci/terraform/core.tf
@@ -1,0 +1,20 @@
+data "terraform_remote_state" "core" {
+  backend = "s3"
+  config = {
+    bucket   = var.common_state_bucket
+    key      = "${var.environment}-core-terraform.tfstate"
+    role_arn = var.deployer_role_arn
+    region   = var.aws_region
+  }
+}
+
+locals {
+  vpc_arn                                    = data.terraform_remote_state.core.outputs.vpc_arn
+  vpc_id                                     = data.terraform_remote_state.core.outputs.vpc_id
+  allow_aws_service_access_security_group_id = data.terraform_remote_state.core.outputs.allow_aws_service_access_security_group_id
+  allow_egress_security_group_id             = data.terraform_remote_state.core.outputs.allow_egress_security_group_id
+  private_subnet_ids                         = data.terraform_remote_state.core.outputs.private_subnet_ids
+  private_subnet_cidr_blocks                 = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
+  public_subnet_ids                          = data.terraform_remote_state.core.outputs.public_subnet_ids
+  public_subnet_cidr_blocks                  = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
+}

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,3 +1,4 @@
-redis_service_plan = "tiny-ha-5_x"
-environment        = "integration"
-your_account_url   = "https://www.integration.publishing.service.gov.uk/account/home"
+redis_service_plan  = "tiny-ha-5_x"
+environment         = "integration"
+your_account_url    = "https://www.integration.publishing.service.gov.uk/account/home"
+common_state_bucket = "digital-identity-dev-tfstate"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,3 +1,5 @@
-redis_service_plan = "large-ha-5_x"
-environment        = "production"
-your_account_url   = "https://www.gov.uk/account/home"
+redis_service_plan  = "large-ha-5_x"
+environment         = "production"
+your_account_url    = "https://www.gov.uk/account/home"
+redis_node_size     = "cache.m4.xlarge"
+common_state_bucket = "digital-identity-prod-tfstate"

--- a/ci/terraform/redis.tf
+++ b/ci/terraform/redis.tf
@@ -1,3 +1,7 @@
+locals {
+  redis_port_number = 6379
+}
+
 data "cloudfoundry_service" "redis" {
   name = "redis"
 }
@@ -8,3 +12,55 @@ resource "cloudfoundry_service_instance" "redis" {
   service_plan = data.cloudfoundry_service.redis.service_plans["${var.redis_service_plan}"]
 }
 
+resource "aws_elasticache_subnet_group" "account_management_redis_session_store" {
+  name       = "${var.environment}-acct-mgmt-redis-frontend-cache-subnet"
+  subnet_ids = local.private_subnet_ids
+
+  tags = local.default_tags
+}
+
+
+resource "random_password" "redis_password" {
+  length = 32
+
+  override_special = "!&#$^<>-"
+  min_lower        = 3
+  min_numeric      = 3
+  min_special      = 3
+  min_upper        = 3
+}
+
+resource "aws_elasticache_replication_group" "account_management_sessions_store" {
+  automatic_failover_enabled    = true
+  availability_zones            = data.aws_availability_zones.available.names
+  replication_group_id          = "${var.environment}-acct-mgmt-frontend-cache"
+  replication_group_description = "A Redis cluster for storing user session data for the account management frontend"
+  node_type                     = var.redis_node_size
+  number_cache_clusters         = length(data.aws_availability_zones.available.names)
+  engine                        = "redis"
+  engine_version                = "6.x"
+  parameter_group_name          = "default.redis6.x"
+  port                          = local.redis_port_number
+  maintenance_window            = "mon:02:00-mon:03:00"
+  notification_topic_arn        = data.aws_sns_topic.slack_events.arn
+
+  multi_az_enabled = true
+
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  auth_token                 = random_password.redis_password.result
+  apply_immediately          = true
+
+  subnet_group_name = aws_elasticache_subnet_group.account_management_redis_session_store.name
+  security_group_ids = [
+    aws_security_group.am_frontend_redis_security_group.id
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      engine_version
+    ]
+  }
+
+  tags = local.default_tags
+}

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -3,3 +3,4 @@ account_management_fqdn = "account-management.sandpit.auth.ida.digital.cabinet-o
 oidc_api_fqdn           = "api.sandpit.auth.ida.digital.cabinet-office.gov.uk"
 environment             = "sandpit"
 your_account_url        = "https://www.gov.uk/account/home"
+common_state_bucket     = "digital-identity-dev-tfstate"

--- a/ci/terraform/security-groups.tf
+++ b/ci/terraform/security-groups.tf
@@ -6,6 +6,8 @@ resource "aws_security_group" "am_frontend_redis_security_group" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = local.default_tags
 }
 
 resource "aws_security_group_rule" "allow_incoming_am_frontend_redis_from_private_subnet" {
@@ -26,6 +28,8 @@ resource "aws_security_group" "allow_access_to_am_frontend_redis" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = local.default_tags
 }
 
 resource "aws_security_group_rule" "allow_connection_to_am_frontend_redis" {

--- a/ci/terraform/security-groups.tf
+++ b/ci/terraform/security-groups.tf
@@ -1,0 +1,39 @@
+resource "aws_security_group" "am_frontend_redis_security_group" {
+  name_prefix = "${var.environment}-am-frontend-redis-security-group-"
+  description = "Allow ingress to AM frontend Redis. Use on Elasticache cluster only"
+  vpc_id      = local.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "allow_incoming_am_frontend_redis_from_private_subnet" {
+  security_group_id = aws_security_group.am_frontend_redis_security_group.id
+
+  from_port   = local.redis_port_number
+  protocol    = "tcp"
+  cidr_blocks = local.private_subnet_cidr_blocks
+  to_port     = local.redis_port_number
+  type        = "ingress"
+}
+
+resource "aws_security_group" "allow_access_to_am_frontend_redis" {
+  name_prefix = "${var.environment}-allow-access-to-acct-mgmt-frontend-redis-"
+  description = "Allow outgoing access to the Account Management frontend Redis session store"
+  vpc_id      = local.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "allow_connection_to_am_frontend_redis" {
+  security_group_id = aws_security_group.allow_access_to_am_frontend_redis.id
+
+  from_port                = local.redis_port_number
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.am_frontend_redis_security_group.id
+  to_port                  = local.redis_port_number
+  type                     = "egress"
+}

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -26,13 +26,6 @@ provider "aws" {
   assume_role {
     role_arn = var.deployer_role_arn
   }
-
-  default_tags {
-    tags = {
-      Environment = var.environment
-      Application = "account-management"
-    }
-  }
 }
 
 provider "cloudfoundry" {
@@ -43,3 +36,12 @@ provider "cloudfoundry" {
 }
 
 provider "random" {}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  default_tags = {
+    environment = var.environment
+    application = "account-management"
+  }
+}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -56,3 +56,6 @@ variable "your_account_url" {
 variable "common_state_bucket" {
 }
 
+variable "redis_node_size" {
+  default = "cache.t2.small"
+}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -52,3 +52,7 @@ variable "your_account_url" {
   type        = string
   description = "the url to the GOV.UK account - Your Account homepage"
 }
+
+variable "common_state_bucket" {
+}
+


### PR DESCRIPTION
## What?

- Add the Terraform to create a new Elasticache Redis cluster for use by the account management application when it migrates to Fargate.
- Swap the AWS provider default tags to using a `local.default_tags` variable as the former doesn't work well all resource types.

## Why?

We are migrating the account management application to Fargate
