### PR TITLE
Fix gov.uk links for cross domain tracking

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -39,12 +39,12 @@
 {% block header %}
  {% if hideSignOutLink %}
     {{ govukHeader({
-           homepageUrl: "https://gov.uk"
+           homepageUrl: 'general.header.homepageHref' | translate
        }) }}
 
   {% else %}
        {{ govukHeader({
-           homepageUrl: "https://gov.uk",
+           homepageUrl: 'general.header.homepageHref' | translate,
            navigationClasses: "govuk-header__navigation--end",
            navigation: [
                {


### PR DESCRIPTION
## What?

Fix gov.uk links in header.

## Why?

This is breaking cross domain tracking.
