### PR TITLE
AUTH-1273: Fix fetching of Redis parameters from SSM

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { setHtmlLangMiddleware } from "./middleware/html-lang-middleware";
 import i18next from "i18next";
 import Backend from "i18next-fs-backend";
 import {
+  getAppEnv,
   getNodeEnv,
   getRedisConfig,
   getSessionExpiry,
@@ -89,7 +90,7 @@ async function createApp(): Promise<express.Application> {
 
   const redisConfig =
     isProduction && isFargate()
-      ? await getRedisConfig(getNodeEnv())
+      ? await getRedisConfig(getAppEnv())
       : undefined;
 
   app.use(

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import CF_CONFIG from "./config/cf";
 import ssm from "./utils/ssm";
 import { RedisConfig } from "./types";
+import { Parameter } from "aws-sdk/clients/ssm";
 
 export function getLogLevel(): string {
   return process.env.LOGS_LEVEL || "debug";
@@ -68,8 +69,8 @@ export function getRedisPort(): number {
 
 export async function getRedisConfig(appEnv: string): Promise<RedisConfig> {
   const hostKey = `${appEnv}-${process.env.REDIS_KEY}-redis-master-host`;
-  const portKey = `${appEnv}-${process.env.REDIS_KEY}-redis-master-port`;
-  const passwordKey = `${appEnv}-${process.env.REDIS_KEY}-redis-master-password`;
+  const portKey = `${appEnv}-${process.env.REDIS_KEY}-redis-port`;
+  const passwordKey = `${appEnv}-${process.env.REDIS_KEY}-redis-password`;
 
   const params = {
     Names: [hostKey, portKey, passwordKey],
@@ -83,9 +84,9 @@ export async function getRedisConfig(appEnv: string): Promise<RedisConfig> {
   }
 
   return {
-    password: result.Parameters[passwordKey].Value,
-    host: result.Parameters[hostKey].Value,
-    port: result.Parameters[portKey].Value,
+    password: result.Parameters.find((p: Parameter) => p.Name === passwordKey).Value,
+    host: result.Parameters.find((p: Parameter) => p.Name === hostKey).Value,
+    port: result.Parameters.find((p: Parameter) => p.Name === portKey).Value,
   };
 }
 


### PR DESCRIPTION
## What?

- Fix the parameter names for port and password (remove the `master-` portion)
- Use APP_ENV rather than NODE_ENV to construct parameter names
- The return type from `getParameters` is a list not map, iterate  appropriately

## Why?

When running in Fargate the app was unable to fetch or parse the parameters.
