### PR TITLE
AUTH-1273: Remove trailing whitespace

### DIFF
--- a/ci/tasks/deploy-account-management.yml
+++ b/ci/tasks/deploy-account-management.yml
@@ -58,7 +58,7 @@ run:
         -var "gov_account_publishing_api_token=${PUBLISHING_API_URL_TOKEN}" \
         -var "cookies_and_feedback_url=${COOKIES_AND_FEEDBACK_URL}" \
         -var "logging_endpoint_arn=${LOGGING_ENDPOINT_ARN}" \
-        -var "logging_endpoint_enabled=${LOGGING_ENDPOINT_ENABLED}" \      
+        -var "logging_endpoint_enabled=${LOGGING_ENDPOINT_ENABLED}" \
         -var-file ${DEPLOY_ENVIRONMENT}.tfvars 
       
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json


### PR DESCRIPTION
## What?

- Remove trailing whitespace in deployment task

## Why?

It seems the trailing whitespace (after the `\`) is being interpreted as an additional parameter. Remove it.

## Related PRs

#321 