### PR TITLE
AUTH-1273: Use shorter name for ALB

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "account_management_alb" {
-  name               = "${var.environment}-account-management-alb"
+  name               = "${var.environment}-acct-mgmt"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.account_management_alb_sg.id]
@@ -11,7 +11,7 @@ resource "aws_lb" "account_management_alb" {
 }
 
 resource "aws_alb_target_group" "account_management_alb_target_group" {
-  name        = "${var.environment}-am-alb-tg"
+  name        = "${var.environment}-acct-mgmt-target"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = local.vpc_id


### PR DESCRIPTION
## What?

- Use a shorter name for the ALB. In our production and integration environments, the previous name was exceeding the 32 character limit.
- Use a nicer name for the ALB target group that is inline with the ALB name

## Why?

Deployment to production and integration is failing due to the length limit.

On reflection, the target group name was previously a little cryptic so bring it in line with the ALB name.