### PR TITLE
AUTH-1278: Deploy to fargate in pipeline

### DIFF
--- a/ci/tasks/deploy-account-management.yml
+++ b/ci/tasks/deploy-account-management.yml
@@ -28,6 +28,7 @@ params:
 
 inputs:
   - name: account-management-src
+  - name: account-management-image
 outputs:
   - name: terraform-outputs
 run:
@@ -35,6 +36,10 @@ run:
   args:
     - -euc
     - |
+      export ACCOUNT_MANAGEMENT_IMAGE_URI=$(cat account-management-image/repository)
+      export ACCOUNT_MANAGEMENT_IMAGE_TAG=$(cat account-management-image/tag)
+      export ACCOUNT_MANAGEMENT_IMAGE_DIGEST=$(cat account-management-image/digest)
+           
       cd "account-management-src/ci/terraform/"
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
@@ -59,6 +64,9 @@ run:
         -var "cookies_and_feedback_url=${COOKIES_AND_FEEDBACK_URL}" \
         -var "logging_endpoint_arn=${LOGGING_ENDPOINT_ARN}" \
         -var "logging_endpoint_enabled=${LOGGING_ENDPOINT_ENABLED}" \
-        -var-file ${DEPLOY_ENVIRONMENT}.tfvars 
+        -var "account_management_image_uri=${ACCOUNT_MANAGEMENT_IMAGE_URI}" \
+        -var "account_management_image_digest=${ACCOUNT_MANAGEMENT_IMAGE_DIGEST}" \
+        -var "account_management_image_tag=${ACCOUNT_MANAGEMENT_IMAGE_TAG}" \
+        -var-file ${DEPLOY_ENVIRONMENT}.tfvars \
       
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -31,8 +31,6 @@ resource "aws_alb_target_group" "account_management_alb_target_group" {
 }
 
 resource "aws_alb_listener" "account_management_alb_listener_https" {
-  count = var.deploy_listener ? 1 : 0
-
   load_balancer_arn = aws_lb.account_management_alb.id
   port              = 443
   protocol          = "HTTPS"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -3,7 +3,3 @@ environment         = "build"
 your_account_url    = ""
 common_state_bucket = "digital-identity-dev-tfstate"
 deploy_listener     = true
-
-# The below are just temporary, and will be removed once they can be injected in the deployment pipeline
-account_management_image_uri    = "761723964695.dkr.ecr.eu-west-2.amazonaws.com/sandpit-account-management-image-repository"
-account_management_image_digest = "sha256:8ffb5f019ace92827442354a045783ba4916c057a13b6489b58df11a1cd9f0de"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -2,4 +2,4 @@ redis_service_plan  = "tiny-ha-5_x"
 environment         = "build"
 your_account_url    = ""
 common_state_bucket = "digital-identity-dev-tfstate"
-deploy_listener     = true
+public_access       = true

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -3,7 +3,3 @@ environment         = "integration"
 your_account_url    = "https://www.integration.publishing.service.gov.uk/account/home"
 common_state_bucket = "digital-identity-dev-tfstate"
 deploy_listener     = true
-
-# The below are just temporary, and will be removed once they can be injected in the deployment pipeline
-account_management_image_uri    = "761723964695.dkr.ecr.eu-west-2.amazonaws.com/sandpit-account-management-image-repository"
-account_management_image_digest = "sha256:8ffb5f019ace92827442354a045783ba4916c057a13b6489b58df11a1cd9f0de"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -2,4 +2,4 @@ redis_service_plan  = "tiny-ha-5_x"
 environment         = "integration"
 your_account_url    = "https://www.integration.publishing.service.gov.uk/account/home"
 common_state_bucket = "digital-identity-dev-tfstate"
-deploy_listener     = true
+public_access       = true

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -4,7 +4,3 @@ your_account_url    = "https://www.gov.uk/account/home"
 redis_node_size     = "cache.m4.xlarge"
 common_state_bucket = "digital-identity-prod-tfstate"
 deploy_listener     = false
-
-# The below are just temporary, and will be removed once they can be injected in the deployment pipeline
-account_management_image_uri    = "761723964695.dkr.ecr.eu-west-2.amazonaws.com/sandpit-account-management-image-repository"
-account_management_image_digest = "sha256:8ffb5f019ace92827442354a045783ba4916c057a13b6489b58df11a1cd9f0de"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -3,4 +3,4 @@ environment         = "production"
 your_account_url    = "https://www.gov.uk/account/home"
 redis_node_size     = "cache.m4.xlarge"
 common_state_bucket = "digital-identity-prod-tfstate"
-deploy_listener     = false
+public_access       = false

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -15,4 +15,4 @@ gtm_id                           = ""
 gov_accounts_publishing_api_url  = ""
 gov_account_publishing_api_token = ""
 cookies_and_feedback_url         = ""
-deploy_listener                  = true
+public_access                  = true

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -15,4 +15,4 @@ gtm_id                           = ""
 gov_accounts_publishing_api_url  = ""
 gov_account_publishing_api_token = ""
 cookies_and_feedback_url         = ""
-public_access                  = true
+public_access                    = true

--- a/ci/terraform/security-groups.tf
+++ b/ci/terraform/security-groups.tf
@@ -54,6 +54,8 @@ resource "aws_security_group" "account_management_alb_sg" {
 }
 
 resource "aws_security_group_rule" "allow_alb_http_ingress_from_anywhere" {
+  count = var.public_access ? 1 : 0
+
   security_group_id = aws_security_group.account_management_alb_sg.id
   type              = "ingress"
 
@@ -65,6 +67,8 @@ resource "aws_security_group_rule" "allow_alb_http_ingress_from_anywhere" {
 }
 
 resource "aws_security_group_rule" "allow_alb_https_ingress_from_anywhere" {
+  count = var.public_access ? 1 : 0
+
   security_group_id = aws_security_group.account_management_alb_sg.id
   type              = "ingress"
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -134,7 +134,7 @@ variable "logging_endpoint_enabled" {
   description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 
-variable "deploy_listener" {
+variable "public_access" {
   type    = bool
   default = false
 }


### PR DESCRIPTION
## What?

- Use the image metadata (repo, tag, digest) provided by the image resource to inject these details into the Terraform deploy.
- Remove default values from environment files.
- Add the listener to production but restrict access in prod by using the security group (required as deployment fails in production with out a listener).

## Why?

We are now building a new image on merge, we need to ensure the details of the new image are passed to Terraform to be deployed to ECS.

We also need to fix the production deploy, previous attempt to secure production by not deploying the listener did not work as a listener needs to be present for the service to deploy successfully.

