### PR TITLE
AUTH-1321: Add a WAF to the account managemnt ALB

### DIFF
--- a/ci/terraform/cloudwatch.tf
+++ b/ci/terraform/cloudwatch.tf
@@ -63,3 +63,20 @@ resource "aws_cloudwatch_log_subscription_filter" "ecs_account_management_task_l
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arn
 }
+
+resource "aws_cloudwatch_log_group" "alb_waf_log" {
+  // Frustratingly, the log group name has to begin with "aws-waf-logs-" so we can't follow our normal convention here
+  name              = "aws-waf-logs-account-management-alb-${var.environment}"
+  kms_key_id        = aws_kms_key.cloudwatch_log_encryption.arn
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "alb_waf_log_subscription" {
+  count           = var.logging_endpoint_enabled ? 1 : 0
+  name            = "${aws_cloudwatch_log_group.alb_waf_log.name}-splunk-subscription"
+  log_group_name  = aws_cloudwatch_log_group.alb_waf_log.name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}

--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -1,0 +1,122 @@
+resource "aws_wafv2_web_acl" "account_management_alb_waf_regional_web_acl" {
+  name  = "${var.environment}-account-management-alb-waf-web-acl"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    action {
+      block {}
+    }
+    priority = 1
+    name     = "${var.environment}-account-management-alb-waf-rate-based-rule"
+    statement {
+      rate_based_statement {
+        limit              = 250
+        aggregate_key_type = "IP"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}AccountManagementAlbWafMaxRequestRate"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    override_action {
+      none {}
+    }
+    priority = 2
+    name     = "${var.environment}-account-management-alb-common-rule-set"
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "GenericRFI_QUERYARGUMENTS"
+        }
+        excluded_rule {
+          name = "GenericRFI_BODY"
+        }
+        dynamic "excluded_rule" {
+          for_each = var.environment != "production" ? ["1"] : []
+          content {
+            name = "EC2MetaDataSSRF_BODY"
+          }
+        }
+        dynamic "excluded_rule" {
+          for_each = var.environment != "production" ? ["1"] : []
+          content {
+            name = "EC2MetaDataSSRF_QUERYARGUMENTS"
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}AccountManagementAlbWafCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    override_action {
+      none {}
+    }
+    priority = 3
+    name     = "${var.environment}-account-management-alb-bad-rule-set"
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}AccountManagementAlbWafBaduleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${replace(var.environment, "-", "")}AccountManagementAlbWafRules"
+    sampled_requests_enabled   = true
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_wafv2_web_acl_association" "alb_waf_association" {
+  resource_arn = aws_lb.account_management_alb.arn
+  web_acl_arn  = aws_wafv2_web_acl.account_management_alb_waf_regional_web_acl.arn
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "frontend_alb_waf_logging_config" {
+  log_destination_configs = [aws_cloudwatch_log_group.alb_waf_log.arn]
+  resource_arn            = aws_wafv2_web_acl.account_management_alb_waf_regional_web_acl.arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+}


### PR DESCRIPTION
## What?

- Add a WebACL to the account management ALB (use same rules as we currently use on API)
- Add logging of blocked requests to a new log group
- Drain log groups to Splunk

## Why?

To secure the ALB we will be using to host the account management frontend