### PR TITLE
AUTH-1316: Bring ECS sizing in line with PaaS deployment

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -10,6 +10,9 @@ resource "aws_ecs_service" "account_management_ecs_service" {
   desired_count   = var.account_management_ecs_desired_count
   launch_type     = "FARGATE"
 
+  deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
+  deployment_maximum_percent         = var.deployment_max_percent
+
   network_configuration {
     security_groups = [
       local.allow_egress_security_group_id,

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -4,3 +4,5 @@ your_account_url    = "https://www.gov.uk/account/home"
 redis_node_size     = "cache.m4.xlarge"
 common_state_bucket = "digital-identity-prod-tfstate"
 public_access       = false
+
+account_management_ecs_desired_count = 4

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -138,3 +138,11 @@ variable "public_access" {
   type    = bool
   default = false
 }
+
+variable "deployment_min_healthy_percent" {
+  default = 50
+}
+
+variable "deployment_max_percent" {
+  default = 100
+}


### PR DESCRIPTION
## What?

- Set instances to 2 for non-prod and 4 prod
- Set deployment strategy as 50% minimum and 100% maximum

## Why?

To ensure the Fargate allocations are similar to that of PaaS.

The deployment strategy was set using Verify Hub as a reference to ensure old versions of tasks don't lurk around after a deployment.
