### PR TITLE
AUTH-1369: Fix naming of service and container

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -1,6 +1,6 @@
 locals {
-  service_name   = "${var.environment}-frontend-ecs-service"
-  container_name = "frontend-application"
+  service_name   = "${var.environment}-account-management-ecs-service"
+  container_name = "account-management-application"
 }
 
 resource "random_string" "session_secret" {


### PR DESCRIPTION
## What?

- In previous PR, we introduced a naming conflict through a copy/paste error.

## Why?

Pipeline is failing due to naming conflict.

## Related PRs

#333 