### PR TITLE
AUTH-1388: Change the hostname on the ALB certs

### DIFF
--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -23,7 +23,7 @@ resource "aws_route53_record" "account_management_fg" {
 }
 
 resource "aws_acm_certificate" "account_management_fg_certificate" {
-  domain_name       = aws_route53_record.account_management_fg.name
+  domain_name       = aws_route53_record.account_management.name
   validation_method = "DNS"
 
   tags = local.default_tags


### PR DESCRIPTION
## What?

- In preparation for the migration lets change the hostname on the ALB TLS certificate to that of the real DNS name of the service.

## Why?

We will pointing the real DNS records at the ALBs in the near future, so let's get the certificates ready.