### PR TITLE
AUTH-1388: Create new certifcates as new resources

### DIFF
--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -23,7 +23,7 @@ resource "aws_route53_record" "account_management_fg" {
 }
 
 resource "aws_acm_certificate" "account_management_fg_certificate" {
-  domain_name       = aws_route53_record.account_management.name
+  domain_name       = aws_route53_record.account_management_fg.name
   validation_method = "DNS"
 
   tags = local.default_tags
@@ -50,4 +50,34 @@ resource "aws_route53_record" "account_management_fg_certificate_validation" {
 resource "aws_acm_certificate_validation" "account_management_fg_acm_certificate_validation" {
   certificate_arn         = aws_acm_certificate.account_management_fg_certificate.arn
   validation_record_fqdns = [for record in aws_route53_record.account_management_fg_certificate_validation : record.fqdn]
+}
+
+resource "aws_acm_certificate" "account_management_alb_certificate" {
+  domain_name       = aws_route53_record.account_management.name
+  validation_method = "DNS"
+
+  tags = local.default_tags
+}
+
+resource "aws_route53_record" "account_management_alb_certificate_validation" {
+
+  for_each = {
+    for dvo in aws_acm_certificate.account_management_alb_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = local.zone_id
+}
+
+resource "aws_acm_certificate_validation" "account_management_acm_alb_certificate_validation" {
+  certificate_arn         = aws_acm_certificate.account_management_alb_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.account_management_alb_certificate_validation : record.fqdn]
 }


### PR DESCRIPTION
## What?

- Revert previous cert rename from #348 
- Create a new resources for the new certificates.

## Why?

Sadly renaming the certificate did not work, as the original is in use. We want the new certificates ready for the rollout.