### PR TITLE
AUTH-1388: Switchover

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -36,7 +36,7 @@ resource "aws_alb_listener" "account_management_alb_listener_https" {
   protocol          = "HTTPS"
 
   ssl_policy      = "ELBSecurityPolicy-2016-08"
-  certificate_arn = aws_acm_certificate.account_management_fg_certificate.arn
+  certificate_arn = aws_acm_certificate.account_management_alb_certificate.arn
 
   default_action {
     target_group_arn = aws_alb_target_group.account_management_alb_target_group.id

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -2,6 +2,5 @@ redis_service_plan  = "tiny-ha-5_x"
 environment         = "build"
 your_account_url    = ""
 common_state_bucket = "digital-identity-dev-tfstate"
-public_access       = true
 
 paas_frontend_cdn_route_destination = "d158sddez3vxwe.cloudfront.net"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -2,6 +2,5 @@ redis_service_plan  = "tiny-ha-5_x"
 environment         = "integration"
 your_account_url    = "https://www.integration.publishing.service.gov.uk/account/home"
 common_state_bucket = "digital-identity-dev-tfstate"
-public_access       = true
 
 paas_frontend_cdn_route_destination = "d3a5c9upzkx78l.cloudfront.net"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -3,7 +3,6 @@ environment         = "production"
 your_account_url    = "https://www.gov.uk/account/home"
 redis_node_size     = "cache.m4.xlarge"
 common_state_bucket = "digital-identity-prod-tfstate"
-public_access       = true
 
 account_management_ecs_desired_count = 4
 paas_frontend_cdn_route_destination  = "d2fete2ah9wab4.cloudfront.net"

--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -5,8 +5,8 @@ resource "aws_route53_record" "account_management" {
 
   alias {
     evaluate_target_health = false
-    name                   = var.paas_frontend_cdn_route_destination
-    zone_id                = var.wellknown_cloudfront_hosted_zone_id
+    name                   = aws_lb.account_management_alb.dns_name
+    zone_id                = aws_lb.account_management_alb.zone_id
   }
 }
 

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -15,4 +15,3 @@ gtm_id                           = ""
 gov_accounts_publishing_api_url  = ""
 gov_account_publishing_api_token = ""
 cookies_and_feedback_url         = ""
-public_access                    = true

--- a/ci/terraform/security-groups.tf
+++ b/ci/terraform/security-groups.tf
@@ -54,8 +54,6 @@ resource "aws_security_group" "account_management_alb_sg" {
 }
 
 resource "aws_security_group_rule" "allow_alb_http_ingress_from_anywhere" {
-  count = var.public_access ? 1 : 0
-
   security_group_id = aws_security_group.account_management_alb_sg.id
   type              = "ingress"
 
@@ -67,8 +65,6 @@ resource "aws_security_group_rule" "allow_alb_http_ingress_from_anywhere" {
 }
 
 resource "aws_security_group_rule" "allow_alb_https_ingress_from_anywhere" {
-  count = var.public_access ? 1 : 0
-
   security_group_id = aws_security_group.account_management_alb_sg.id
   type              = "ingress"
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -134,11 +134,6 @@ variable "logging_endpoint_enabled" {
   description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 
-variable "public_access" {
-  type    = bool
-  default = false
-}
-
 variable "deployment_min_healthy_percent" {
   default = 50
 }


### PR DESCRIPTION
## What?

- Remove the flag that controls the creation of the security group rule allowing ingress from anywhere.
- Switch the account management DNS record (`account.gov.uk`) to point at the Fargate ALB.
- Ensure the Fargate ALB is using the correct certificate.

## Why?

We are ready to switchover hosting of the frontend.
