### PR TITLE
AUTH-1388: Set number of APP_INSTANCE to 3 for deployment

### DIFF
--- a/ci/tasks/deploy-account-management.yml
+++ b/ci/tasks/deploy-account-management.yml
@@ -16,7 +16,7 @@ params:
   CF_USERNAME: ((cf-username))
   CF_PASSWORD: ((cf-password))
   CF_ORG_NAME: ((cf-org-name))
-  APP_INSTANCES: 1
+  APP_INSTANCES: 3
   GTM_ID: ((build-gtm-id))
   PUBLISHING_API_URL: ((build-gov-accounts-api-url))
   PUBLISHING_API_URL_TOKEN: ((build-gov-accounts-api-token))


### PR DESCRIPTION
## What?

- In the deployment task set `APP_INSTANCES` to a default value of 3

## Why?

Deployment was picking up a default value of 1, which is too low to allow a ZDD deployment.