### PR TITLE
AUTH-1388: Use tfvars for number of instances

### DIFF
--- a/ci/tasks/deploy-account-management.yml
+++ b/ci/tasks/deploy-account-management.yml
@@ -16,7 +16,6 @@ params:
   CF_USERNAME: ((cf-username))
   CF_PASSWORD: ((cf-password))
   CF_ORG_NAME: ((cf-org-name))
-  APP_INSTANCES: 3
   GTM_ID: ((build-gtm-id))
   PUBLISHING_API_URL: ((build-gov-accounts-api-url))
   PUBLISHING_API_URL_TOKEN: ((build-gov-accounts-api-token))
@@ -56,7 +55,6 @@ run:
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
         -var "dns_state_key=${DNS_STATE_KEY}" \
         -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
-        -var "account_management_ecs_desired_count=${APP_INSTANCES}" \
         -var "session_expiry=${SESSION_EXPIRY}" \
         -var "gtm_id=${GTM_ID}" \
         -var "gov_accounts_publishing_api_url=${PUBLISHING_API_URL}" \


### PR DESCRIPTION
## What?

- We have the number of instances being overridden in both in the environment specific `.tfvars` file and in the pipeline deploy task, lets remove the variable from the task and rely on the `.tfvars`

## Why?

Injected variables from the deploy task should be reserved for secrets only.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/502
https://github.com/alphagov/di-infrastructure/pull/165