### PR TITLE
AUTH-1389: Remove Cloudfoundry provider from Terraform

### DIFF
--- a/ci/tasks/deploy-account-management.yml
+++ b/ci/tasks/deploy-account-management.yml
@@ -13,9 +13,6 @@ params:
   DNS_STATE_KEY: ((dns-state-key))
   STATE_BUCKET: digital-identity-dev-tfstate
   DEPLOY_ENVIRONMENT: build
-  CF_USERNAME: ((cf-username))
-  CF_PASSWORD: ((cf-password))
-  CF_ORG_NAME: ((cf-org-name))
   GTM_ID: ((build-gtm-id))
   PUBLISHING_API_URL: ((build-gov-accounts-api-url))
   PUBLISHING_API_URL_TOKEN: ((build-gov-accounts-api-token))
@@ -49,9 +46,6 @@ run:
 
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
-        -var "cf_username=${CF_USERNAME}" \
-        -var "cf_password=${CF_PASSWORD}" \
-        -var "cf_org_name=${CF_ORG_NAME}" \
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
         -var "dns_state_key=${DNS_STATE_KEY}" \
         -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \

--- a/ci/terraform/.terraform.lock.hcl
+++ b/ci/terraform/.terraform.lock.hcl
@@ -1,34 +1,12 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
-  version     = "0.14.2"
-  constraints = "0.14.2"
-  hashes = [
-    "h1:qgPDV+Q6AfVnDRn4eP+0Jm9aHKACody/Oa3FuZRoifU=",
-    "zh:0a8184b3bb0b5d8934c1f9e988fcf0da13ce05f666d6b7861cf50b74496e5a23",
-    "zh:0afa174665bdd728e7a9951952a0ef91526677f9b8c57250e210e696ec84c861",
-    "zh:0dfdd0288641dcecd5d9c894546163b51fbd2f576a83c5013f82dbf86067a8c1",
-    "zh:310c32a75986e797525b89ae41a45021bd64ee46858c7e68f4504c763440da19",
-    "zh:5d99fbedaddfe12830efec6b2387552d1ea10bda22596fcd46bc75994cdfd4b5",
-    "zh:60ecd53ec4e6795f0392d8701015a6efefb0446174ad20cbe2cdc0ca9f984a9e",
-    "zh:6763498656278a703b6045ab401ebf55346341d8891c2a70c7916585b6577f33",
-    "zh:7aa63f571c434dd2cd76a7fd7140a928eb10e1f629c93627a0afd8c1c78d6808",
-    "zh:8dec45aa1705272975958a859dd53960638816d0ea793c671715c9c1a353b2d0",
-    "zh:957db10a90ae964c9ed05c2653d44e738beac61239e4a57c7c47378eba33dff7",
-    "zh:9effa3a98bcdf39f2db2be56ac34b2b901ca78740acc9f317c9a3e757a0f76b1",
-    "zh:a3c4d51590bce8fccc504c7e357b322a12702180c92a4d682d269983df29765a",
-    "zh:b11b17166836f86a5bca92a2776ba6ef57de0298072bd8c677c82744361d57cb",
-    "zh:c4a338ff3f5bf9514c64c6c0aa7883c43d14920b84d1faa54876ffd722bfc434",
-    "zh:fa9191416e2d73e3aaa835eb04643e179bf0f4d9d97fd3f03088e3a989606543",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.57.0"
   constraints = ">= 3.56.0"
   hashes = [
     "h1:H6JCnoa3swF3rgHL0ys9KNArffU+IEGPvhQ6JnfQY/c=",
+    "h1:kFpEsbiU2cfwl0IL8/pCfF2fcUXjAfJagipLjQO2qUU=",
     "zh:241a4203078ea35f63202b613f0e4b428a842734ded62d9f487cdf7c2a66d639",
     "zh:2c1cbf3cd03a2a7ff267be09cedf1698738c372b1411ca74cfcb3bf4b0846f27",
     "zh:318ad2331f60e03d284f90f728486b9df7ac9570af641c43b56216357e624b52",
@@ -47,6 +25,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.0"
   constraints = ">= 3.1.0"
   hashes = [
+    "h1:9cCiLO/Cqr6IUvMDSApCkQItooiYNatZpEXmcu0nnng=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -1,4 +1,3 @@
-cf_org_name                         = "gds-digital-identity-authentication"
 account_management_fqdn             = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
 oidc_api_fqdn                       = "api.sandpit.auth.ida.digital.cabinet-office.gov.uk"
 frontend_fqdn                       = "signin.sandpit.auth.ida.digital.cabinet-office.gov.uk"

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.1.0"
     }
-    cloudfoundry = {
-      source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.14.2"
-    }
   }
 
   backend "s3" {
@@ -26,13 +22,6 @@ provider "aws" {
   assume_role {
     role_arn = var.deployer_role_arn
   }
-}
-
-provider "cloudfoundry" {
-  api_url      = "https://api.london.cloud.service.gov.uk"
-  user         = var.cf_username
-  password     = var.cf_password
-  app_logs_max = 250
 }
 
 provider "random" {}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -6,18 +6,6 @@ variable "deployer_role_arn" {
   default = null
 }
 
-variable "cf_username" {
-  description = "deployer username"
-}
-
-variable "cf_password" {
-  description = "deployer password org"
-}
-
-variable "cf_org_name" {
-  description = "target org"
-}
-
 variable "dns_state_bucket" {
   default = ""
 }


### PR DESCRIPTION
## What?

- Remove the, now unused, Cloudfoundry provider from Terraform
- Remove related variables used for Cloudfoundry authentication
- Update deploy task to reflect above changes

## Why?

We no longer have any managed PaaS (Cloudfoundry) resources.