### PR TITLE
AUTH-1839: Remove the generation of the acc-mgmt-fg DNS and cert

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -48,9 +48,6 @@ resource "aws_dynamodb_table_item" "account_management_client" {
         {
           S = "https://${local.account_management_fqdn}/account-deleted-confirmation"
         },
-        {
-          S = "https://${aws_route53_record.account_management_fg.fqdn}/account-deleted-confirmation"
-        }
       ]
     }
     RedirectUrls = {
@@ -58,9 +55,6 @@ resource "aws_dynamodb_table_item" "account_management_client" {
         {
           S = "https://${local.account_management_fqdn}/auth/callback"
         },
-        {
-          S = "https://${aws_route53_record.account_management_fg.fqdn}/auth/callback"
-        }
       ]
     }
     Scopes = {

--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -44,7 +44,7 @@ resource "aws_alb_listener" "account_management_alb_listener_https" {
   }
 
   depends_on = [
-    aws_acm_certificate_validation.account_management_fg_acm_certificate_validation
+    aws_acm_certificate_validation.account_management_acm_alb_certificate_validation
   ]
 
   tags = local.default_tags

--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -10,48 +10,6 @@ resource "aws_route53_record" "account_management" {
   }
 }
 
-resource "aws_route53_record" "account_management_fg" {
-  name    = "acc-mgmt-fg.${local.service_domain}"
-  type    = "A"
-  zone_id = local.zone_id
-
-  alias {
-    evaluate_target_health = false
-    name                   = aws_lb.account_management_alb.dns_name
-    zone_id                = aws_lb.account_management_alb.zone_id
-  }
-}
-
-resource "aws_acm_certificate" "account_management_fg_certificate" {
-  domain_name       = aws_route53_record.account_management_fg.name
-  validation_method = "DNS"
-
-  tags = local.default_tags
-}
-
-resource "aws_route53_record" "account_management_fg_certificate_validation" {
-
-  for_each = {
-    for dvo in aws_acm_certificate.account_management_fg_certificate.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
-  allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
-  type            = each.value.type
-  zone_id         = local.zone_id
-}
-
-resource "aws_acm_certificate_validation" "account_management_fg_acm_certificate_validation" {
-  certificate_arn         = aws_acm_certificate.account_management_fg_certificate.arn
-  validation_record_fqdns = [for record in aws_route53_record.account_management_fg_certificate_validation : record.fqdn]
-}
-
 resource "aws_acm_certificate" "account_management_alb_certificate" {
   domain_name       = aws_route53_record.account_management.name
   validation_method = "DNS"


### PR DESCRIPTION
## What?

- Remove the route53 resource `acc-mgmt-fg.<domain>`
- Remove the ACM resources for generating a certificate for the above domain name.

## Why?

The `acc-mgmt-fg.<domain>` was a testing hostname during the migration from PaaS to ECS.
