### PR TITLE
AUTH-1446 - Default to null if supportInternationalNumbers is set to false

### DIFF
--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -15,7 +15,7 @@ const TEMPLATE_NAME = "change-phone-number/index.njk";
 
 export function changePhoneNumberGet(req: Request, res: Response): void {
   res.render("change-phone-number/index.njk", {
-    supportInternationalNumbers: supportInternationalNumbers(),
+    supportInternationalNumbers: supportInternationalNumbers() ? true : null,
   });
 }
 


### PR DESCRIPTION
## What?

- Default to null if supportInternationalNumbers is set to false

## Why?

- So it correctly renders the correct content when there has been a validation failure
