### PR TITLE
AUTH-1427: Parameterise ALB allowlist

### DIFF
--- a/ci/tasks/deploy-account-management.yml
+++ b/ci/tasks/deploy-account-management.yml
@@ -22,6 +22,7 @@ params:
   LOGGING_ENDPOINT_ENABLED: "true"
   DEPLOY_LISTENER: "true"
   SUPPORT_INTERNATIONAL_NUMBERS: "0"
+  INCOMING_TRAFFIC_CIDR_BLOCKS: '["0.0.0.0/0"]'
 
 inputs:
   - name: account-management-src
@@ -61,6 +62,7 @@ run:
         -var "account_management_image_digest=${ACCOUNT_MANAGEMENT_IMAGE_DIGEST}" \
         -var "account_management_image_tag=${ACCOUNT_MANAGEMENT_IMAGE_TAG}" \
         -var "support_international_numbers=${SUPPORT_INTERNATIONAL_NUMBERS}" \
+        -var "incoming_traffic_cidr_blocks=${INCOMING_TRAFFIC_CIDR_BLOCKS}" \
         -var-file ${DEPLOY_ENVIRONMENT}.tfvars \
       
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/security-groups.tf
+++ b/ci/terraform/security-groups.tf
@@ -61,7 +61,7 @@ resource "aws_security_group_rule" "allow_alb_http_ingress_from_anywhere" {
   protocol    = "tcp"
   from_port   = 80
   to_port     = 80
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = var.incoming_traffic_cidr_blocks
 }
 
 resource "aws_security_group_rule" "allow_alb_https_ingress_from_anywhere" {
@@ -72,7 +72,7 @@ resource "aws_security_group_rule" "allow_alb_https_ingress_from_anywhere" {
   protocol    = "tcp"
   from_port   = 443
   to_port     = 443
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = var.incoming_traffic_cidr_blocks
 }
 
 resource "aws_security_group_rule" "allow_alb_application_egress_to_task_group" {

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -133,3 +133,9 @@ variable "wellknown_cloudfront_hosted_zone_id" {
   description = "This is the well know hosted zone ID for all cloudfront destinations"
   type        = string
 }
+
+variable "incoming_traffic_cidr_blocks" {
+  default     = ["0.0.0.0/0"]
+  type        = list(string)
+  description = "The list of CIDR blocks allowed to send requests to the ALB"
+}


### PR DESCRIPTION
## What?

- Make the CIDR block used for to match incoming traffic to the ALB parameterised. The default should be anywhere (`["0.0.0.0/0"]`)

## Why?

This will allow us to override in the pipeline for staging and other environments.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/560