### PR TITLE
AUT-252: Back channel logout route and validation

### DIFF
--- a/@types/express/index.d.ts
+++ b/@types/express/index.d.ts
@@ -8,6 +8,7 @@ declare namespace Express {
     csrfToken?: () => string;
     session: any;
     oidc?: Client;
+    issuerJWKS?: any;
     log?: any;
   }
 }

--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -57,6 +57,9 @@ resource "aws_dynamodb_table_item" "account_management_client" {
         },
       ]
     }
+    BackChannelLogoutUri = {
+      S = "https://${local.account_management_fqdn}/global-logout"
+    }
     Scopes = {
       L = [for scope in local.scopes :
         {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -70,6 +70,7 @@ export const PATH_DATA: {
   SIGN_OUT: { url: "/sign-out" },
   START: { url: "/" },
   HEALTHCHECK: { url: "/healthcheck" },
+  GLOBAL_LOGOUT: { url: "/global-logout" },
 };
 
 export const API_ENDPOINTS = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -112,6 +112,7 @@ async function createApp(): Promise<express.Application> {
 
   app.use(healthcheckRouter);
   app.use(authMiddleware(getOIDCConfig()));
+  app.use(globalLogoutRouter);
   app.use(csurf({ cookie: getCSRFCookieOptions(isProduction) }));
 
   app.post("*", sanitizeRequestMiddleware);
@@ -131,7 +132,6 @@ async function createApp(): Promise<express.Application> {
   app.use(deleteAccountRouter);
   app.use(checkYourPhoneRouter);
   app.use(sessionExpiredRouter);
-  app.use(globalLogoutRouter);
 
   app.use(logErrorMiddleware);
   app.use(serverErrorHandler);

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,6 +48,7 @@ import { noCacheMiddleware } from "./middleware/no-cache-middleware";
 import { sessionExpiredRouter } from "./components/session-expired/session-expired-routes";
 import { setLocalVarsMiddleware } from "./middleware/set-local-vars-middleware";
 import { healthcheckRouter } from "./components/healthcheck/healthcheck-routes";
+import { globalLogoutRouter } from "./components/global-logout/global-logout-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -130,6 +131,7 @@ async function createApp(): Promise<express.Application> {
   app.use(deleteAccountRouter);
   app.use(checkYourPhoneRouter);
   app.use(sessionExpiredRouter);
+  app.use(globalLogoutRouter);
 
   app.use(logErrorMiddleware);
   app.use(serverErrorHandler);

--- a/src/components/change-email/tests/change-email-integration.test.ts
+++ b/src/components/change-email/tests/change-email-integration.test.ts
@@ -56,6 +56,12 @@ describe("Integration:: change email", () => {
       });
     });
 
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
     app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 

--- a/src/components/change-password/tests/change-password-integration.test.ts
+++ b/src/components/change-password/tests/change-password-integration.test.ts
@@ -54,6 +54,12 @@ describe("Integration:: change password", () => {
       });
     });
 
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
     app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 

--- a/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
@@ -58,6 +58,12 @@ describe("Integration:: change phone number", () => {
       });
     });
 
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
     app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -57,6 +57,12 @@ describe("Integration:: check your email", () => {
       });
     });
 
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
     app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
     govUkPublishingBaseApi = process.env.GOV_ACCOUNTS_PUBLISHING_API_URL;

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -54,6 +54,12 @@ describe("Integration:: check your phone", () => {
       });
     });
 
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
     app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -66,6 +66,12 @@ describe("Integration:: delete account", () => {
       });
     });
 
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
     app = await require("../../../app").createApp();
 
     baseApi = process.env.AM_API_BASE_URL;

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -62,6 +62,12 @@ describe("Integration::enter password", () => {
       });
     });
 
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
     app = await require("../../../app").createApp();
     baseApi = process.env.AM_API_BASE_URL;
 

--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -1,38 +1,43 @@
 import { Request, Response } from "express";
 import { HTTP_STATUS_CODES } from "../../app.constants";
 import { GlobalLogoutServiceInterface, LogoutToken } from "./types";
-import { getLogoutTokenMaxAge, getTokenValidationClockSkew } from "../../config";
+import {
+  getLogoutTokenMaxAge,
+  getTokenValidationClockSkew,
+} from "../../config";
 import { ExpressRouteFunc } from "../../types";
 import { globalLogoutService } from "./global-logout-service";
-const jose = require('jose')
+const jose = require("jose");
 
-const backChannelLogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
-
+const backChannelLogoutEvent =
+  "http://schemas.openid.net/event/backchannel-logout";
 
 const verifyLogoutToken = async (req: Request): Promise<LogoutToken> => {
   if (!(req.body && Object.keys(req.body).includes("logout_token"))) {
     return undefined;
   }
   try {
-    const token = await jose.jwtVerify(
-      req.body.logout_token,
-      req.issuerJWKS, {
-        issuer: req.oidc.issuer.metadata.issuer,
-        audience: req.oidc.metadata.client_id,
-        maxTokenAge: getLogoutTokenMaxAge(),
-        clockTolerance: getTokenValidationClockSkew(),
-      });
+    const token = await jose.jwtVerify(req.body.logout_token, req.issuerJWKS, {
+      issuer: req.oidc.issuer.metadata.issuer,
+      audience: req.oidc.metadata.client_id,
+      maxTokenAge: getLogoutTokenMaxAge(),
+      clockTolerance: getTokenValidationClockSkew(),
+    });
 
     return token.payload;
   } catch (e) {
-    req.log.error(new Error(`Unable to validate logout_token. Error: ${e.message}`));
+    req.log.error(
+      new Error(`Unable to validate logout_token. Error: ${e.message}`)
+    );
     return undefined;
   }
 };
 
-
-const validateLogoutTokenClaims = (token: LogoutToken, req: Request): boolean => {
-  if ((!token.sub) || /^\s*$/.test(token.sub)) {
+const validateLogoutTokenClaims = (
+  token: LogoutToken,
+  req: Request
+): boolean => {
+  if (!token.sub || /^\s*$/.test(token.sub)) {
     req.log.error(new Error(`Logout token does not contain a subject`));
     return false;
   }
@@ -41,15 +46,21 @@ const validateLogoutTokenClaims = (token: LogoutToken, req: Request): boolean =>
     return false;
   }
   if (!(backChannelLogoutEvent in token.events)) {
-    req.log.error(new Error(`Logout token does not contain correct event: ${token.events}`));
+    req.log.error(
+      new Error(`Logout token does not contain correct event: ${token.events}`)
+    );
     return false;
   }
   if (Object.keys(token.events[backChannelLogoutEvent]).length > 0) {
-    req.log.error(new Error(`Logout token back-channel logout event is not an empty object: ${token.events[backChannelLogoutEvent]}`));
+    req.log.error(
+      new Error(
+        `Logout token back-channel logout event is not an empty object: ${token.events[backChannelLogoutEvent]}`
+      )
+    );
     return false;
   }
   return true;
-}
+};
 
 export function globalLogoutPost(
   service: GlobalLogoutServiceInterface = globalLogoutService()
@@ -63,5 +74,5 @@ export function globalLogoutPost(
       return;
     }
     res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
-  }
+  };
 }

--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -16,8 +16,8 @@ const verifyLogoutToken = async (req: Request): Promise<LogoutToken> => {
       req.issuerJWKS, {
         issuer: req.oidc.issuer.metadata.issuer,
         audience: req.oidc.metadata.client_id,
-        maxTokenAge: 600,
-        clockTolerance: 10,
+        maxTokenAge: getLogoutTokenMaxAge(),
+        clockTolerance: getTokenValidationClockSkew(),
       });
 
     return token.payload;

--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -3,30 +3,57 @@ import { HTTP_STATUS_CODES } from "../../app.constants";
 import { LogoutToken } from "./types";
 const jose = require('jose')
 
+const backChannelLogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
+
 const verifyLogoutToken = async (req: Request): Promise<LogoutToken> => {
   if (!(req.body && Object.keys(req.body).includes("logout_token"))) {
     return undefined;
   }
   try {
-    const token = await jose.compactVerify(
+    const token = await jose.jwtVerify(
       req.body.logout_token,
-      req.issuerJWKS);
+      req.issuerJWKS, {
+        issuer: req.oidc.issuer.metadata.issuer,
+        audience: req.oidc.metadata.client_id,
+        maxTokenAge: 600,
+        clockTolerance: 10,
+      });
 
-    return new TextDecoder().decode(token.payload);
+    return token.payload;
   } catch (e) {
     req.log.error(new Error(`Unable to validate logout_token. Error: ${e.message}`));
     return undefined;
   }
 };
 
-export async function globalLogoutPost(req: Request, res: Response): Promise<void> {
 
+const validateLogoutTokenClaims = (token: LogoutToken, req: Request): boolean => {
+  if ((!token.sub) || /^\s*$/.test(token.sub)) {
+    req.log.error(new Error(`Logout token does not contain a subject`));
+    return false;
+  }
+  if (!token.events) {
+    req.log.error(new Error(`Logout token does not contain any event`));
+    return false;
+  }
+  if (!(backChannelLogoutEvent in token.events)) {
+    req.log.error(new Error(`Logout token does not contain correct event: ${token.events}`));
+    return false;
+  }
+  if (Object.keys(token.events[backChannelLogoutEvent]).length > 0) {
+    req.log.error(new Error(`Logout token back-channel logout event is not an empty object: ${token.events[backChannelLogoutEvent]}`));
+    return false;
+  }
+  return true;
+}
+
+export async function globalLogoutPost(req: Request, res: Response): Promise<void> {
   const token = await verifyLogoutToken(req);
 
-  if (token) {
+  if (token && validateLogoutTokenClaims(token, req)) {
     res.status(HTTP_STATUS_CODES.OK);
     return;
   }
   res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
-
 }

--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from "express";
+
+export async function globalLogoutPost(req: Request, res: Response): Promise<void> {
+
+}

--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -1,5 +1,37 @@
 import { Request, Response } from "express";
+import { HTTP_STATUS_CODES } from "../../app.constants";
+import { LogoutToken } from "./types";
+const jose = require('jose')
+
+const verifyLogoutToken = async (req: Request): Promise<LogoutToken> => {
+  if (!(req.body && Object.keys(req.body).includes("logout_token"))) {
+    return undefined;
+  }
+  try {
+    const token = await jose.JWT.LogoutToken.verify(
+      req.body.logout_token,
+      "",
+      {
+        issuer: req.oidc.issuer.metadata.issuer,
+        audience: req.oidc.metadata.client_id,
+        algorithms: [req.oidc.metadata.id_token_signed_response_alg]
+      });
+
+    return token.payload;
+  } catch (e) {
+    req.log.error(`Unable to validate logout_token. Error:${e.message}`);
+    return undefined;
+  }
+};
 
 export async function globalLogoutPost(req: Request, res: Response): Promise<void> {
+
+  const token = await verifyLogoutToken(req);
+
+  if (token) {
+    res.status(HTTP_STATUS_CODES.OK);
+    return;
+  }
+  res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
 
 }

--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -8,18 +8,13 @@ const verifyLogoutToken = async (req: Request): Promise<LogoutToken> => {
     return undefined;
   }
   try {
-    const token = await jose.JWT.LogoutToken.verify(
+    const token = await jose.compactVerify(
       req.body.logout_token,
-      "",
-      {
-        issuer: req.oidc.issuer.metadata.issuer,
-        audience: req.oidc.metadata.client_id,
-        algorithms: [req.oidc.metadata.id_token_signed_response_alg]
-      });
+      req.issuerJWKS);
 
-    return token.payload;
+    return new TextDecoder().decode(token.payload);
   } catch (e) {
-    req.log.error(`Unable to validate logout_token. Error:${e.message}`);
+    req.log.error(new Error(`Unable to validate logout_token. Error: ${e.message}`));
     return undefined;
   }
 };

--- a/src/components/global-logout/global-logout-routes.ts
+++ b/src/components/global-logout/global-logout-routes.ts
@@ -1,0 +1,10 @@
+import * as express from "express";
+import { globalLogoutPost } from "./global-logout-controller";
+import { PATH_DATA } from "../../app.constants";
+import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
+
+const router = express.Router();
+
+router.post(PATH_DATA.GLOBAL_LOGOUT.url, requiresAuthMiddleware, globalLogoutPost);
+
+export { router as globalLogoutRouter };

--- a/src/components/global-logout/global-logout-routes.ts
+++ b/src/components/global-logout/global-logout-routes.ts
@@ -1,10 +1,11 @@
 import * as express from "express";
 import { globalLogoutPost } from "./global-logout-controller";
 import { PATH_DATA } from "../../app.constants";
-import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
+import { authMiddleware } from "../../middleware/auth-middleware";
+import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();
 
-router.post(PATH_DATA.GLOBAL_LOGOUT.url, requiresAuthMiddleware, globalLogoutPost);
+router.post(PATH_DATA.GLOBAL_LOGOUT.url, asyncHandler(globalLogoutPost()));
 
 export { router as globalLogoutRouter };

--- a/src/components/global-logout/global-logout-routes.ts
+++ b/src/components/global-logout/global-logout-routes.ts
@@ -1,7 +1,6 @@
 import * as express from "express";
 import { globalLogoutPost } from "./global-logout-controller";
 import { PATH_DATA } from "../../app.constants";
-import { authMiddleware } from "../../middleware/auth-middleware";
 import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();

--- a/src/components/global-logout/global-logout-service.ts
+++ b/src/components/global-logout/global-logout-service.ts
@@ -1,14 +1,10 @@
 import { GlobalLogoutServiceInterface } from "./types";
 import { RedisStore } from "connect-redis";
 
-export function globalLogoutService(
-
-): GlobalLogoutServiceInterface {
+export function globalLogoutService(): GlobalLogoutServiceInterface {
   const clearSessionForSubject = async function (
     subjectId: string
-  ): Promise<void> {
-
-  };
+  ): Promise<void> {};
 
   return {
     clearSessionForSubject,

--- a/src/components/global-logout/global-logout-service.ts
+++ b/src/components/global-logout/global-logout-service.ts
@@ -1,10 +1,11 @@
 import { GlobalLogoutServiceInterface } from "./types";
-import { RedisStore } from "connect-redis";
 
 export function globalLogoutService(): GlobalLogoutServiceInterface {
   const clearSessionForSubject = async function (
     subjectId: string
-  ): Promise<void> {};
+  ): Promise<void> {
+    `Logout request received for ${subjectId}`;
+  };
 
   return {
     clearSessionForSubject,

--- a/src/components/global-logout/global-logout-service.ts
+++ b/src/components/global-logout/global-logout-service.ts
@@ -1,0 +1,16 @@
+import { GlobalLogoutServiceInterface } from "./types";
+import { RedisStore } from "connect-redis";
+
+export function globalLogoutService(
+
+): GlobalLogoutServiceInterface {
+  const clearSessionForSubject = async function (
+    subjectId: string
+  ): Promise<void> {
+
+  };
+
+  return {
+    clearSessionForSubject,
+  };
+}

--- a/src/components/global-logout/tests/global-logout-controller.test.ts
+++ b/src/components/global-logout/tests/global-logout-controller.test.ts
@@ -1,0 +1,65 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { HTTP_STATUS_CODES } from "../../../app.constants";
+import { globalLogoutPost } from "../global-logout-controller";
+
+describe("global logout controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    const oidc = require("../../../utils/oidc");
+    sandbox.stub(oidc, "getOIDCClient").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({
+          endSessionUrl: function (params: any = {}) {
+            return `${process.env.API_BASE_URL}/logout?id_token_hint=${
+              params.id_token_hint
+            }&post_logout_redirect_uri=${encodeURIComponent(
+              params.post_logout_redirect_uri
+            )}`;
+          },
+        });
+      });
+    });
+
+    res = {
+      status: sandbox.stub().returnsThis(),
+      send: sandbox.fake(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("globalLogoutPost", async () => {
+    it("should return 401 if no logout_token present", async () => {
+      req = {
+        body: {},
+      };
+      await globalLogoutPost(req as Request, res as Response);
+
+      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+    });
+
+    it("should return 401 if no logout_token not a signed JWT", async () => {
+      req = {
+        body: {
+          logout_token: "zzzzzzzz"
+        },
+        log: { error: sandbox.fake() }
+      };
+      await globalLogoutPost(req as Request, res as Response)
+
+      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(req.log.error).to.have.been.called;
+    });
+  });
+});

--- a/src/components/global-logout/tests/global-logout-controller.test.ts
+++ b/src/components/global-logout/tests/global-logout-controller.test.ts
@@ -53,10 +53,7 @@ describe("global logout controller", () => {
     };
   };
 
-  const generateValidToken = async (
-    token: any,
-    subjectId: string = "123456"
-  ) => {
+  const generateValidToken = async (token: any, subjectId = "123456") => {
     return await new jose.SignJWT(token)
       .setIssuedAt()
       .setSubject(subjectId)

--- a/src/components/global-logout/tests/global-logout-controller.test.ts
+++ b/src/components/global-logout/tests/global-logout-controller.test.ts
@@ -5,9 +5,9 @@ import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 import { HTTP_STATUS_CODES } from "../../../app.constants";
 import { globalLogoutPost } from "../global-logout-controller";
-import { FlattenedJWSInput, GetKeyFunction, JWSHeaderParameters, KeyLike } from "jose/dist/types/types";
+import { FlattenedJWSInput, GetKeyFunction, JWSHeaderParameters } from "jose/dist/types/types";
 import { GenerateKeyPairResult } from "jose";
-import { LogoutToken } from "../types";
+import { GlobalLogoutServiceInterface, LogoutToken } from "../types";
 
 const jose = require('jose')
 
@@ -17,6 +17,7 @@ describe("global logout controller",  () => {
   let res: Partial<Response>;
   let issuerJWKS: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput>;
   let keySet: GenerateKeyPairResult;
+  let fakeService: GlobalLogoutServiceInterface;
 
   const validIssuer = "urn:example:issuer";
   const validAudience = "urn:example:audience";
@@ -80,6 +81,10 @@ describe("global logout controller",  () => {
       status: sandbox.stub().returnsThis(),
       send: sandbox.fake(),
     };
+
+    fakeService = {
+      clearSessionForSubject: sandbox.fake(),
+    };
   });
 
   afterEach(async () => {
@@ -91,7 +96,7 @@ describe("global logout controller",  () => {
       req = {
         body: {},
       };
-      await globalLogoutPost(req as Request, res as Response);
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
     });
@@ -103,7 +108,7 @@ describe("global logout controller",  () => {
         },
         log: { error: sandbox.fake() }
       };
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -119,7 +124,7 @@ describe("global logout controller",  () => {
 
       req = validRequest(logoutJwt);
 
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -138,7 +143,7 @@ describe("global logout controller",  () => {
 
       req = validRequest(logoutJwt);
 
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -155,7 +160,7 @@ describe("global logout controller",  () => {
 
       req = validRequest(logoutJwt);
 
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -171,7 +176,7 @@ describe("global logout controller",  () => {
         .sign(keySet.privateKey);
 
       req = validRequest(logoutJwt);
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -187,7 +192,7 @@ describe("global logout controller",  () => {
         .sign(keySet.privateKey);
 
       req = validRequest(logoutJwt);
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -202,7 +207,7 @@ describe("global logout controller",  () => {
         .sign(keySet.privateKey);
 
       req = validRequest(logoutJwt);
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -210,7 +215,7 @@ describe("global logout controller",  () => {
 
     it("should return 401 if logout_token is blank", async () => {
       req = validRequest(await generateValidToken(validLogoutToken, " "));
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -227,7 +232,7 @@ describe("global logout controller",  () => {
 
       req = validRequest(await generateValidToken(invalidLogoutToken));
 
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -241,7 +246,7 @@ describe("global logout controller",  () => {
 
       req = validRequest(await generateValidToken(invalidLogoutToken));
 
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -258,7 +263,7 @@ describe("global logout controller",  () => {
 
       req = validRequest(await generateValidToken(invalidLogoutToken));
 
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -276,7 +281,7 @@ describe("global logout controller",  () => {
       };
 
       req = validRequest(await generateValidToken(invalidLogoutToken));
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
@@ -285,7 +290,7 @@ describe("global logout controller",  () => {
     it("should return 200 if logout_token is present and valid", async () => {
       req = validRequest(await generateValidToken(validLogoutToken));
 
-      await globalLogoutPost(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response)
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.OK);
     });

--- a/src/components/global-logout/tests/global-logout-controller.test.ts
+++ b/src/components/global-logout/tests/global-logout-controller.test.ts
@@ -5,13 +5,17 @@ import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 import { HTTP_STATUS_CODES } from "../../../app.constants";
 import { globalLogoutPost } from "../global-logout-controller";
-import { FlattenedJWSInput, GetKeyFunction, JWSHeaderParameters } from "jose/dist/types/types";
+import {
+  FlattenedJWSInput,
+  GetKeyFunction,
+  JWSHeaderParameters,
+} from "jose/dist/types/types";
 import { GenerateKeyPairResult } from "jose";
 import { GlobalLogoutServiceInterface, LogoutToken } from "../types";
 
-const jose = require('jose')
+const jose = require("jose");
 
-describe("global logout controller",  () => {
+describe("global logout controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
   let res: Partial<Response>;
@@ -22,40 +26,43 @@ describe("global logout controller",  () => {
   const validIssuer = "urn:example:issuer";
   const validAudience = "urn:example:audience";
   const validLogoutToken = {
-    "jti": "a-token-id",
-    "sid": "a-session-id",
-    "events": {
-      "http://schemas.openid.net/event/backchannel-logout": {}
-    }
+    jti: "a-token-id",
+    sid: "a-session-id",
+    events: {
+      "http://schemas.openid.net/event/backchannel-logout": {},
+    },
   };
 
   const validRequest = (logoutJwt: LogoutToken) => {
     return {
       body: {
-        logout_token: logoutJwt
+        logout_token: logoutJwt,
       },
       log: { error: sandbox.fake() },
       issuerJWKS: issuerJWKS,
       oidc: {
         issuer: {
           metadata: {
-            issuer: validIssuer
-          }
+            issuer: validIssuer,
+          },
         },
         metadata: {
-          client_id: validAudience
+          client_id: validAudience,
         },
-      }
+      },
     };
   };
 
-  const generateValidToken = async (token: any, subjectId: string = "123456") => {
+  const generateValidToken = async (
+    token: any,
+    subjectId: string = "123456"
+  ) => {
     return await new jose.SignJWT(token)
       .setIssuedAt()
       .setSubject(subjectId)
       .setIssuer(validIssuer)
       .setAudience(validAudience)
-      .setProtectedHeader({ alg: 'ES256' })
+      .setProtectedHeader({ alg: "ES256" })
       .sign(keySet.privateKey);
   };
 
@@ -65,17 +72,15 @@ describe("global logout controller",  () => {
     const oidc = require("../../../utils/oidc");
     sandbox.stub(oidc, "getOIDCClient").callsFake(() => {
       return new Promise((resolve) => {
-        resolve({
-        });
+        resolve({});
       });
     });
 
-    keySet = await jose.generateKeyPair('ES256');
+    keySet = await jose.generateKeyPair("ES256");
 
     issuerJWKS = await jose.createLocalJWKSet({
-      keys: [
-        await jose.exportJWK(keySet.publicKey)
-      ]});
+      keys: [await jose.exportJWK(keySet.publicKey)],
+    });
 
     res = {
       status: sandbox.stub().returnsThis(),
@@ -98,19 +103,23 @@ describe("global logout controller",  () => {
       };
       await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
     });
 
     it("should return 401 if logout_token not a valid JWT", async () => {
       req = {
         body: {
-          logout_token: "zzzzzzzz"
+          logout_token: "zzzzzzzz",
         },
-        log: { error: sandbox.fake() }
+        log: { error: sandbox.fake() },
       };
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
@@ -124,28 +133,32 @@ describe("global logout controller",  () => {
 
       req = validRequest(logoutJwt);
 
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
     it("should return 401 if logout_token signed by wrong key", async () => {
-      const badKeys = await jose.generateKeyPair('ES256');
+      const badKeys = await jose.generateKeyPair("ES256");
 
       const logoutJwt = await new jose.SignJWT(validLogoutToken)
         .setIssuedAt()
         .setSubject("12345")
         .setIssuer(validIssuer)
         .setAudience(validAudience)
-        .setProtectedHeader({ alg: 'ES256' })
+        .setProtectedHeader({ alg: "ES256" })
         .sign(badKeys.privateKey);
 
       req = validRequest(logoutJwt);
 
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
@@ -155,14 +168,16 @@ describe("global logout controller",  () => {
         .setSubject("12345")
         .setIssuer("arn:bad:issuer")
         .setAudience(validAudience)
-        .setProtectedHeader({ alg: 'ES256' })
+        .setProtectedHeader({ alg: "ES256" })
         .sign(keySet.privateKey);
 
       req = validRequest(logoutJwt);
 
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
@@ -172,13 +187,15 @@ describe("global logout controller",  () => {
         .setSubject("12345")
         .setIssuer(validIssuer)
         .setAudience("arn:bad:audience")
-        .setProtectedHeader({ alg: 'ES256' })
+        .setProtectedHeader({ alg: "ES256" })
         .sign(keySet.privateKey);
 
       req = validRequest(logoutJwt);
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
@@ -188,13 +205,15 @@ describe("global logout controller",  () => {
         .setSubject("12345")
         .setIssuer(validIssuer)
         .setAudience(validAudience)
-        .setProtectedHeader({ alg: 'ES256' })
+        .setProtectedHeader({ alg: "ES256" })
         .sign(keySet.privateKey);
 
       req = validRequest(logoutJwt);
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
@@ -203,94 +222,106 @@ describe("global logout controller",  () => {
         .setIssuedAt()
         .setIssuer(validIssuer)
         .setAudience(validAudience)
-        .setProtectedHeader({ alg: 'ES256' })
+        .setProtectedHeader({ alg: "ES256" })
         .sign(keySet.privateKey);
 
       req = validRequest(logoutJwt);
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
     it("should return 401 if logout_token is blank", async () => {
       req = validRequest(await generateValidToken(validLogoutToken, " "));
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
     it("should return 401 if logout_token does not contain correct event", async () => {
       const invalidLogoutToken = {
-        "jti": "a-token-id",
-        "sid": "a-session-id",
-        "events": {
-          "not-a-valid-event": {}
-        }
+        jti: "a-token-id",
+        sid: "a-session-id",
+        events: {
+          "not-a-valid-event": {},
+        },
       };
 
       req = validRequest(await generateValidToken(invalidLogoutToken));
 
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
     it("should return 401 if logout_token does not any events", async () => {
       const invalidLogoutToken = {
-        "jti": "a-token-id",
-        "sid": "a-session-id",
+        jti: "a-token-id",
+        sid: "a-session-id",
       };
 
       req = validRequest(await generateValidToken(invalidLogoutToken));
 
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
     it("should return 401 if logout_token contains invalid event", async () => {
       const invalidLogoutToken = {
-        "jti": "a-token-id",
-        "sid": "a-session-id",
-        "events": {
-          "bad-event": {}
-        }
+        jti: "a-token-id",
+        sid: "a-session-id",
+        events: {
+          "bad-event": {},
+        },
       };
 
       req = validRequest(await generateValidToken(invalidLogoutToken));
 
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
     it("should return 401 if logout_token contains valid but non-empty event", async () => {
       const invalidLogoutToken = {
-        "jti": "a-token-id",
-        "sid": "a-session-id",
-        "events": {
+        jti: "a-token-id",
+        sid: "a-session-id",
+        events: {
           "http://schemas.openid.net/event/backchannel-logout": {
-            "an": "invalid-value"
-          }
-        }
+            an: "invalid-value",
+          },
+        },
       };
 
       req = validRequest(await generateValidToken(invalidLogoutToken));
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
-      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.status).to.have.been.calledWith(
+        HTTP_STATUS_CODES.UNAUTHORIZED
+      );
       expect(req.log.error).to.have.been.called;
     });
 
     it("should return 200 if logout_token is present and valid", async () => {
       req = validRequest(await generateValidToken(validLogoutToken));
 
-      await globalLogoutPost(fakeService)(req as Request, res as Response)
+      await globalLogoutPost(fakeService)(req as Request, res as Response);
 
       expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.OK);
     });

--- a/src/components/global-logout/types.ts
+++ b/src/components/global-logout/types.ts
@@ -1,13 +1,13 @@
 export interface LogoutToken {
-    iss: string,
-    sub?: string,
-    aud: string,
-    iat: number,
-    jti: string,
-    sid?: string,
-    events?: any
+  iss: string;
+  sub?: string;
+  aud: string;
+  iat: number;
+  jti: string;
+  sid?: string;
+  events?: any;
 }
 
 export interface GlobalLogoutServiceInterface {
-    clearSessionForSubject: (subjectId: string) => Promise<void>;
+  clearSessionForSubject: (subjectId: string) => Promise<void>;
 }

--- a/src/components/global-logout/types.ts
+++ b/src/components/global-logout/types.ts
@@ -7,3 +7,7 @@ export interface LogoutToken {
     sid?: string,
     events?: any
 }
+
+export interface GlobalLogoutServiceInterface {
+    clearSessionForSubject: (subjectId: string) => Promise<void>;
+}

--- a/src/components/global-logout/types.ts
+++ b/src/components/global-logout/types.ts
@@ -1,0 +1,9 @@
+export interface LogoutToken {
+    "iss": string,
+    "sub": string,
+    "aud": string,
+    "iat": number,
+    "jti": string,
+    "sid": string,
+    "events": Map<string, any>
+}

--- a/src/components/global-logout/types.ts
+++ b/src/components/global-logout/types.ts
@@ -1,9 +1,9 @@
 export interface LogoutToken {
-    "iss": string,
-    "sub": string,
-    "aud": string,
-    "iat": number,
-    "jti": string,
-    "sid": string,
-    "events": Map<string, any>
+    iss: string,
+    sub?: string,
+    aud: string,
+    iat: number,
+    jti: string,
+    sid?: string,
+    events?: any
 }

--- a/src/components/manage-your-account/tests/manage-your-account-integration.test.ts
+++ b/src/components/manage-your-account/tests/manage-your-account-integration.test.ts
@@ -36,6 +36,12 @@ describe("Integration:: manage your account", () => {
       });
     });
 
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
     app = await require("../../../app").createApp();
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,7 +106,7 @@ export function getCookiesAndFeedbackLink(): string {
 }
 
 export function getBaseUrl(): string {
-  const baseUrl = process.env.BASE_URL ?? "localhost:6001";
+  const baseUrl = process.env.BASE_URL ?? "localhost:6000";
   return getProtocol() + baseUrl;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,7 +106,7 @@ export function getCookiesAndFeedbackLink(): string {
 }
 
 export function getBaseUrl(): string {
-  const baseUrl = process.env.BASE_URL ?? "localhost:6000";
+  const baseUrl = process.env.BASE_URL ?? "localhost:6001";
   return getProtocol() + baseUrl;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,14 +123,13 @@ export function supportInternationalNumbers(): boolean {
 }
 
 export function getLogoutTokenMaxAge(): number {
-  return Number(process.env.LOGOUT_TOKEN_MAX_AGE_SECONDS) || 120
+  return Number(process.env.LOGOUT_TOKEN_MAX_AGE_SECONDS) || 120;
 }
 
 export function getTokenValidationClockSkew(): number {
-  return Number(process.env.TOKEN_CLOCK_SKEW) || 10
+  return Number(process.env.TOKEN_CLOCK_SKEW) || 10;
 }
 
 function getProtocol(): string {
   return getAppEnv() !== "local" ? "https://" : "http://";
 }
-

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,15 @@ export function supportInternationalNumbers(): boolean {
   return process.env.SUPPORT_INTERNATIONAL_NUMBERS === "1";
 }
 
+export function getLogoutTokenMaxAge(): number {
+  return Number(process.env.LOGOUT_TOKEN_MAX_AGE_SECONDS) || 120
+}
+
+export function getTokenValidationClockSkew(): number {
+  return Number(process.env.TOKEN_CLOCK_SKEW) || 10
+}
+
 function getProtocol(): string {
   return getAppEnv() !== "local" ? "https://" : "http://";
 }
+

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { getOIDCClient } from "../utils/oidc";
+import { getJWKS, getOIDCClient } from "../utils/oidc";
 import { ExpressRouteFunc, OIDCConfig } from "../types";
 import { ApiError } from "../utils/errors";
 
@@ -8,6 +8,7 @@ export function authMiddleware(config: OIDCConfig): ExpressRouteFunc {
     req.oidc = await getOIDCClient(config).catch((err: any) => {
       throw new ApiError(err.message);
     });
+    req.issuerJWKS = await getJWKS(config);
     next();
   };
 }

--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -98,4 +98,9 @@ function clientAssertionGenerator(
   };
 }
 
-export { cached as getOIDCClient, cachedJwks as getJWKS, isTokenExpired, clientAssertionGenerator };
+export {
+  cached as getOIDCClient,
+  cachedJwks as getJWKS,
+  isTokenExpired,
+  clientAssertionGenerator,
+};


### PR DESCRIPTION
## What?

- Add a `/global-logout` route that accepts a `POST` request
- Validate that the `POST` request contains a valid logout request JWT
- Pull in issuer JWKS to validate JWT signature

## Why?

This sets up the route for the back channel global logout functionality. This PR does not actually do the logout but the endpoint will provide the correct responses. Logout functionality to follow.

