### PR TITLE
AUT-294 -  Set ClientType to web for AM client

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -78,6 +78,9 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     },
     ConsentRequired = {
       N = "0"
+    },
+    ClientType = {
+      S = "web"
     }
   })
 }


### PR DESCRIPTION
## What?

- Set ClientType to web

## Why?

- A new field has been added to the ClientRegistry to support app clients. Explicitly set the AM RP ClientType to `web`

