### PR TITLE
AUT-212: ECS rollout configuration tweaks in build and integration only

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -11,11 +11,12 @@ resource "aws_lb" "account_management_alb" {
 }
 
 resource "aws_alb_target_group" "account_management_alb_target_group" {
-  name        = "${var.environment}-acct-mgmt-target"
-  port        = 80
-  protocol    = "HTTP"
-  vpc_id      = local.vpc_id
-  target_type = "ip"
+  name                 = "${var.environment}-acct-mgmt-target"
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = local.vpc_id
+  target_type          = "ip"
+  deregistration_delay = var.deregistration_delay
 
   health_check {
     healthy_threshold   = "3"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -2,3 +2,4 @@ environment                       = "build"
 your_account_url                  = ""
 common_state_bucket               = "digital-identity-dev-tfstate"
 health_check_grace_period_seconds = 15
+deregistration_delay = 30

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,3 +1,4 @@
-environment         = "build"
-your_account_url    = ""
-common_state_bucket = "digital-identity-dev-tfstate"
+environment                       = "build"
+your_account_url                  = ""
+common_state_bucket               = "digital-identity-dev-tfstate"
+health_check_grace_period_seconds = 15

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -2,4 +2,4 @@ environment                       = "build"
 your_account_url                  = ""
 common_state_bucket               = "digital-identity-dev-tfstate"
 health_check_grace_period_seconds = 15
-deregistration_delay = 30
+deregistration_delay              = 30

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -17,6 +17,7 @@ resource "aws_ecs_service" "account_management_ecs_service" {
 
   deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
   deployment_maximum_percent         = var.deployment_max_percent
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
 
   network_configuration {
     security_groups = [
@@ -25,9 +26,8 @@ resource "aws_ecs_service" "account_management_ecs_service" {
       aws_security_group.account_management_ecs_tasks_sg.id,
       aws_security_group.allow_access_to_am_frontend_redis.id,
     ]
-    subnets                           = local.private_subnet_ids
-    assign_public_ip                  = false
-    health_check_grace_period_seconds = var.health_check_grace_period_seconds
+    subnets          = local.private_subnet_ids
+    assign_public_ip = false
   }
 
   load_balancer {

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -25,8 +25,9 @@ resource "aws_ecs_service" "account_management_ecs_service" {
       aws_security_group.account_management_ecs_tasks_sg.id,
       aws_security_group.allow_access_to_am_frontend_redis.id,
     ]
-    subnets          = local.private_subnet_ids
-    assign_public_ip = false
+    subnets                           = local.private_subnet_ids
+    assign_public_ip                  = false
+    health_check_grace_period_seconds = var.health_check_grace_period_seconds
   }
 
   load_balancer {

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,3 +1,4 @@
-environment         = "integration"
-your_account_url    = "https://www.integration.publishing.service.gov.uk/account/home"
-common_state_bucket = "digital-identity-dev-tfstate"
+environment                       = "integration"
+your_account_url                  = "https://www.integration.publishing.service.gov.uk/account/home"
+common_state_bucket               = "digital-identity-dev-tfstate"
+health_check_grace_period_seconds = 15

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -2,4 +2,4 @@ environment                       = "integration"
 your_account_url                  = "https://www.integration.publishing.service.gov.uk/account/home"
 common_state_bucket               = "digital-identity-dev-tfstate"
 health_check_grace_period_seconds = 15
-deregistration_delay = 30
+deregistration_delay              = 30

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -2,3 +2,4 @@ environment                       = "integration"
 your_account_url                  = "https://www.integration.publishing.service.gov.uk/account/home"
 common_state_bucket               = "digital-identity-dev-tfstate"
 health_check_grace_period_seconds = 15
+deregistration_delay = 30

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -128,6 +128,10 @@ variable "deployment_max_percent" {
   default = 150
 }
 
+variable "health_check_grace_period_seconds" {
+  default = 0
+}
+
 variable "wellknown_cloudfront_hosted_zone_id" {
   default     = "Z2FDTNDATAQYW2"
   description = "This is the well know hosted zone ID for all cloudfront destinations"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -132,6 +132,10 @@ variable "health_check_grace_period_seconds" {
   default = 0
 }
 
+variable "deregistration_delay" {
+  default = 300
+}
+
 variable "wellknown_cloudfront_hosted_zone_id" {
   default     = "Z2FDTNDATAQYW2"
   description = "This is the well know hosted zone ID for all cloudfront destinations"


### PR DESCRIPTION
## What?

ECS rollout configuration tweaks in build and integration only.

- Set health_check_grace_period_seconds to 15s.  Current default is 0.
- Set ALB deregistration_delay to 30s.  Current default is 300s.

Changes to be extended to staging and prod after checks in build and integration.

## Why?

We currently have these two configuration values set to their defaults.

Currently waiting 300s for the apps to drain during a rollout as the deregistration delay is set to the default.  Frontend transactions complete in a matter of seconds so there is no reason to wait for 5 mins.  This will reduce rollout timeout.

See the ECS service event log when a rollout happens, it takes 5 mins between deregistration (when the ALB stops sending traffice to the app) and finally stopping the app.  Nothing happens during this time.

2022-05-06 11:48:26 +0100
service has stopped 2 running tasks: 

2022-05-06 11:43:24 +0100
service  has begun draining connections on 2 tasks.

2022-05-06 11:43:24 +0100
service  deregistered 2 targets in target-group 

Frontend apps start quickly but a small grace period makes sense just in case to allow for connections (to redis for example).
