### PR TITLE
AUT-213: rollout auto scaling to int and staging

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -2,4 +2,5 @@ environment         = "build"
 your_account_url    = ""
 common_state_bucket = "digital-identity-dev-tfstate"
 
-account_management_auto_scaling_enabled = true
+account_management_auto_scaling_enabled   = true
+account_management_task_definition_memory = 1024

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -2,5 +2,4 @@ environment         = "build"
 your_account_url    = ""
 common_state_bucket = "digital-identity-dev-tfstate"
 
-account_management_auto_scaling_enabled   = true
-account_management_task_definition_memory = 1024
+account_management_auto_scaling_enabled = true

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -2,5 +2,4 @@ environment         = "integration"
 your_account_url    = "https://www.integration.publishing.service.gov.uk/account/home"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-account_management_auto_scaling_enabled   = true
-account_management_task_definition_memory = 1024
+account_management_auto_scaling_enabled = true

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,3 +1,6 @@
 environment         = "integration"
 your_account_url    = "https://www.integration.publishing.service.gov.uk/account/home"
 common_state_bucket = "digital-identity-dev-tfstate"
+
+account_management_auto_scaling_enabled   = true
+account_management_task_definition_memory = 1024

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -1,3 +1,6 @@
 environment         = "staging"
 your_account_url    = "https://www.staging.publishing.service.gov.uk/account/home"
 common_state_bucket = "di-auth-staging-tfstate"
+
+account_management_auto_scaling_enabled   = true
+account_management_task_definition_memory = 1024

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -2,5 +2,4 @@ environment         = "staging"
 your_account_url    = "https://www.staging.publishing.service.gov.uk/account/home"
 common_state_bucket = "di-auth-staging-tfstate"
 
-account_management_auto_scaling_enabled   = true
-account_management_task_definition_memory = 1024
+account_management_auto_scaling_enabled = true


### PR DESCRIPTION
## What?

Rollout auto scaling to int and staging.

We should be able to reduce both CPU and memory down further later on and scale out instead given the existing headroom.

## Why?

Scaling up and down has been proven in build using the performance tests.

## Related PRs

#463 
#461 
