### PR TITLE
AUT-381 - Set IdentityVerificationSupported to false in the Client Registry 

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -79,5 +79,8 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     ConsentRequired = {
       N = "0"
     }
+    IdentityVerificationSupported = {
+      N = "0"
+    }
   })
 }


### PR DESCRIPTION
## What?

- Set IdentityVerificationSupported to false in the Client Registry 

## Why?

- AM doesn't support identity, so set the new field 'IdentityVerificationSupported' in the client registry to false