### PR TITLE
AUT-401: update content for session timeout to 2hrs

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -93,7 +93,7 @@
       "title": "You have been signed out",
       "header": "You have been signed out",
       "content": {
-        "paragraph1": "You’ve been signed out because you did not use your account for 60 minutes or more.",
+        "paragraph1": "You’ve been signed out because you did not use your account for more than 2 hours.",
         "paragraph2": "This is to keep your account and your information secure.",
         "signInButtonText": "Sign in to your account",
         "govUKHomepageLink": "https://www.gov.uk/",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -93,7 +93,7 @@
       "title": "You have been signed out",
       "header": "You have been signed out",
       "content": {
-        "paragraph1": "You’ve been signed out because you did not use your account for 60 minutes or more.",
+        "paragraph1": "You’ve been signed out because you did not use your account for more than 2 hours.",
         "paragraph2": "This is to keep your account and your information secure.",
         "signInButtonText": "Sign in to your account",
         "govUKHomepageLink": "https://www.gov.uk/",


### PR DESCRIPTION
## What?

Update content for session timeout to 2hrs.

## Why?

Session timeout is being increased to 2hrs to cater for long-running identity flows.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/1919
https://github.com/alphagov/di-authentication-frontend/pull/598
