### PR TITLE
AUT-302 - Remove check to see if string contains letter

### DIFF
--- a/src/components/change-password/change-password-validation.ts
+++ b/src/components/change-password/change-password-validation.ts
@@ -1,6 +1,5 @@
 import { body } from "express-validator";
 import {
-  containsLettersOnly,
   containsNumber,
   containsNumbersOnly,
 } from "../../utils/strings";
@@ -30,8 +29,7 @@ export function validateChangePasswordRequest(): ValidationChainFunc {
         if (
           !containsNumber(value) ||
           containsNumbersOnly(value) ||
-          value.length < 8 ||
-          containsLettersOnly(value)
+          value.length < 8
         ) {
           throw new Error(
             req.t("pages.changePassword.password.validationError.alphaNumeric")

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -8,10 +8,6 @@ export function containsNumbersOnly(value: string): boolean {
   return value ? /^\d+$/.test(value) : false;
 }
 
-export function containsLettersOnly(value: string): boolean {
-  return value ? /^[a-zA-Z]+$/.test(value) : false;
-}
-
 export function redactPhoneNumber(value: string): string | undefined {
   return value
     ? "*".repeat(value.length - 4) + value.trim().slice(value.length - 4)

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import { describe } from "mocha";
 import {
-  containsLettersOnly,
   containsNumber,
   containsNumbersOnly,
   redactPhoneNumber,
@@ -38,31 +37,13 @@ describe("string-helpers", () => {
     it("should return false when string is null", () => {
       expect(containsNumbersOnly(null)).to.equal(false);
     });
+
     it("should return false when string contains alphanumeric characters", () => {
       expect(containsNumbersOnly("test123456")).to.equal(false);
     });
+
     it("should return true when string contains numeric characters only", () => {
       expect(containsNumbersOnly("123456")).to.equal(true);
-    });
-  });
-
-  describe("hasLettersOnly", () => {
-    it("should return false when string contains only numbers", () => {
-      expect(containsLettersOnly("1234")).to.equal(false);
-    });
-
-    it("should return false when string is empty", () => {
-      expect(containsLettersOnly("")).to.equal(false);
-    });
-
-    it("should return false when string is null", () => {
-      expect(containsLettersOnly(null)).to.equal(false);
-    });
-    it("should return false when string contains alphanumeric characters", () => {
-      expect(containsLettersOnly("test123456")).to.equal(false);
-    });
-    it("should return true when string contains letters characters only", () => {
-      expect(containsLettersOnly("abcdefg")).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## What?

- Remove check to see if string contains letter

## Why?

- We already do this by checking whether the string contains a number so we can remove this redundant validation

