### PR TITLE
DCP-147 include preload directive in HSTS

### DIFF
--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -34,7 +34,7 @@ export const helmetConfiguration: Parameters<typeof helmet>[0] = {
   },
   hsts: {
     maxAge: 31536000, // 1 Year
-    preload: false,
+    preload: true,
     includeSubDomains: true,
   },
   referrerPolicy: false,


### PR DESCRIPTION

## What?

include preload directive in HSTS

## Why?

so we can add *.account.gov.uk to the preload list

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/624
https://github.com/alphagov/di-authentication-api/pull/2049