### PR TITLE
AUT-474 - Provide option to enter 44 or +44 before UK number

### DIFF
--- a/src/components/change-phone-number/change-phone-number-validation.ts
+++ b/src/components/change-phone-number/change-phone-number-validation.ts
@@ -4,7 +4,6 @@ import { ValidationChainFunc } from "../../types";
 import {
   containsInternationalMobileNumber,
   containsLeadingPlusNumbersOrSpacesOnly,
-  containsNumbersOrSpacesOnly,
   containsUKMobileNumber,
   lengthInRangeWithoutSpaces,
 } from "../../utils/phone-number";
@@ -22,17 +21,17 @@ export function validateChangePhoneNumberRequest(): ValidationChainFunc {
         );
       })
       .custom((value, { req }) => {
-        if (!containsNumbersOrSpacesOnly(value)) {
+        if (!containsLeadingPlusNumbersOrSpacesOnly(value)) {
           throw new Error(
             req.t(
-              "pages.changePhoneNumber.ukPhoneNumber.validationError.numeric"
+              "pages.changePhoneNumber.ukPhoneNumber.validationError.plusNumericOnly"
             )
           );
         }
         return true;
       })
       .custom((value, { req }) => {
-        if (!lengthInRangeWithoutSpaces(value, 10, 11)) {
+        if (!lengthInRangeWithoutSpaces(value, 10, 14)) {
           throw new Error(
             req.t(
               "pages.changePhoneNumber.ukPhoneNumber.validationError.length"

--- a/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
@@ -147,7 +147,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK Phone number using numbers only"
+          "Enter a UK mobile phone number using only numbers or the + symbol"
         );
       })
       .expect(400, done);
@@ -199,6 +199,66 @@ describe("Integration:: change phone number", () => {
       .send({
         _csrf: token,
         phoneNumber: "07738394991",
+      })
+      .expect("Location", "/check-your-phone")
+      .expect(302, done);
+  });
+
+  it("should redirect to /check-your-phone page when valid UK phone number prefixed with +447 is entered", (done) => {
+    nock(baseApi).post(API_ENDPOINTS.SEND_NOTIFICATION).once().reply(204, {});
+
+    request(app)
+      .post(PATH_DATA.CHANGE_PHONE_NUMBER.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        phoneNumber: "+447738394991",
+      })
+      .expect("Location", "/check-your-phone")
+      .expect(302, done);
+  });
+
+  it("should redirect to /check-your-phone page when valid UK phone number prefixed with 447 is entered", (done) => {
+    nock(baseApi).post(API_ENDPOINTS.SEND_NOTIFICATION).once().reply(204, {});
+
+    request(app)
+      .post(PATH_DATA.CHANGE_PHONE_NUMBER.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        phoneNumber: "447738394991",
+      })
+      .expect("Location", "/check-your-phone")
+      .expect(302, done);
+  });
+
+  it("should redirect to /check-your-phone page when valid UK phone number prefixed with 440 is entered", (done) => {
+    nock(baseApi).post(API_ENDPOINTS.SEND_NOTIFICATION).once().reply(204, {});
+
+    request(app)
+      .post(PATH_DATA.CHANGE_PHONE_NUMBER.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        phoneNumber: "4407738394991",
+      })
+      .expect("Location", "/check-your-phone")
+      .expect(302, done);
+  });
+
+  it("should redirect to /check-your-phone page when valid UK phone number prefixed with +440 is entered", (done) => {
+    nock(baseApi).post(API_ENDPOINTS.SEND_NOTIFICATION).once().reply(204, {});
+
+    request(app)
+      .post(PATH_DATA.CHANGE_PHONE_NUMBER.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        phoneNumber: "+4407738394991",
       })
       .expect("Location", "/check-your-phone")
       .expect(302, done);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -292,7 +292,7 @@
           "required": "Enter a UK phone number",
           "international": "Enter a UK phone number",
           "length": "Enter a UK phone number, like 07700 900000",
-          "numeric": "Enter a UK Phone number using numbers only",
+          "plusNumericOnly": "Enter a UK mobile phone number using only numbers or the + symbol",
           "samePhoneNumber": "Your account is already using that phone number. Enter a different phone number."
         }
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -292,7 +292,7 @@
           "required": "Enter a UK phone number",
           "international": "Enter a UK phone number",
           "length": "Enter a UK phone number, like 07700 900000",
-          "numeric": "Enter a UK Phone number using numbers only",
+          "plusNumericOnly": "Enter a UK mobile phone number using only numbers or the + symbol",
           "samePhoneNumber": "Your account is already using that phone number. Enter a different phone number."
         }
       },

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -1,11 +1,9 @@
 import { isValidPhoneNumber } from "libphonenumber-js/mobile";
 
 export function containsUKMobileNumber(value: string): boolean {
-  return isValidPhoneNumber(value, "GB");
-}
-
-export function containsNumbersOrSpacesOnly(value: string): boolean {
-  return value ? /^[\d\s]+$/.test(value) : false;
+  return (
+    isValidPhoneNumber(value, "GB") && /^([+?44]{2}|[07]{2}).*$/.test(value)
+  );
 }
 
 export function containsInternationalMobileNumber(value: string): boolean {

--- a/test/unit/utils/phone-number.test.ts
+++ b/test/unit/utils/phone-number.test.ts
@@ -2,7 +2,6 @@ import { expect } from "chai";
 import { describe } from "mocha";
 import {
   containsInternationalMobileNumber,
-  containsNumbersOrSpacesOnly,
   containsUKMobileNumber,
   lengthInRangeWithoutSpaces,
   prependInternationalPrefix,
@@ -53,27 +52,29 @@ describe("phone-number", () => {
     it("should return false when premium rate number entered", () => {
       expect(containsUKMobileNumber("0909 8790000")).to.equal(false);
     });
-  });
 
-  describe("containsNumbersOrSpacesOnly", () => {
-    it("should return false when non numeric character is in string", () => {
-      expect(containsNumbersOrSpacesOnly("test")).to.equal(false);
+    it("should return true with leading +44 before 0", () => {
+      expect(containsUKMobileNumber("+4407911123456")).to.equal(true);
     });
 
-    it("should return false when symbol is in string", () => {
-      expect(containsNumbersOrSpacesOnly("!!")).to.equal(false);
+    it("should return true with leading +44 without 0", () => {
+      expect(containsUKMobileNumber("+447911123456")).to.equal(true);
     });
 
-    it("should return true when spaces only in string", () => {
-      expect(containsNumbersOrSpacesOnly("   ")).to.equal(true);
+    it("should return false when starting with +33 before 0", () => {
+      expect(containsUKMobileNumber("+330645453322")).to.equal(false);
     });
 
-    it("should return true when numbers only in string", () => {
-      expect(containsNumbersOrSpacesOnly("1234567")).to.equal(true);
+    it("should return false when starting with +33 without 0", () => {
+      expect(containsUKMobileNumber("+33645453322")).to.equal(false);
     });
 
-    it("should return true when spaces and numbers in string", () => {
-      expect(containsNumbersOrSpacesOnly("123 4567 33")).to.equal(true);
+    it("should return false when only a single 4 is present", () => {
+      expect(containsUKMobileNumber("+47911123456")).to.equal(false);
+    });
+
+    it("should return false when missing 7", () => {
+      expect(containsUKMobileNumber("+44911123456")).to.equal(false);
     });
   });
 


### PR DESCRIPTION
## What?

- Provide option to enter 44 or +44 before UK number
- Some users use +44 or 44 when entering their phone numbers. Adapt the validation to allow this.
- Add regex to the phone-number validation for checking a UK number. This is because relying on isValidPhoneNumber allowed some numbers which were not UK numbers through. Such as +33.
- Change the validation text to represent the changes made.


## Why?

- Previously users could enter a UK number such as 07738393990. Allow users to enter their UK numbers in one of the following formats in addition to what we currently allow +447738393990, +4407738393990, 447738393990, 4407738393990.
