### PR TITLE
BAU: Add a known ID to an element on page for smoketests

### DIFF
--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -4,7 +4,7 @@
 {% set pageTitleName = 'pages.manageYourAccount.title' | translate %}
 
 {% block content %}
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" id="#your-account">
   <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
     <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.manageYourAccount.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.manageYourAccount.signedInStatus' | translate }} <strong>{{ email }}</strong></p>


### PR DESCRIPTION
## What?

- Add an ID to the `govuk-grid-row` element.

## Why?

The smoketests wait for a known element on page to be rendered.

## Related PRs

