### PR TITLE
BAU: Remove # from ID name

### DIFF
--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -4,7 +4,7 @@
 {% set pageTitleName = 'pages.manageYourAccount.title' | translate %}
 
 {% block content %}
-<div class="govuk-grid-row" id="#your-account">
+<div class="govuk-grid-row" id="your-account">
   <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
     <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.manageYourAccount.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.manageYourAccount.signedInStatus' | translate }} <strong>{{ email }}</strong></p>


### PR DESCRIPTION
## What?

- Remove incorrectly added `#` from element ID

## Why?

The `#` should be there as creates an invalid ID name.

## Related PRs

#522 
https://github.com/alphagov/di-authentication-smoke-tests/pull/47