### PR TITLE
AUT-473: Do not open all footer links in a new tab

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -89,22 +89,18 @@
             items: [
                 {
                     href: authFrontEndUrl + "/accessibility-statement",
-                    attributes: { target: "_blank"},
                     text: 'general.footer.accessibilityStatement.linkText' | translate
                 },
                 {
                     href: "https://www.gov.uk/help/cookies",
-                    attributes: { target: "_blank"},
                     text: 'general.footer.cookies.linkText' | translate
                 },
                 {
                     href: authFrontEndUrl + "/terms-and-conditions",
-                    attributes: { target: "_blank"},
                     text: 'general.footer.terms.linkText' | translate
                 },
                 {
                     href: authFrontEndUrl + "/privacy-notice",
-                    attributes: { target: "_blank"},
                     text: 'general.footer.privacy.linkText' | translate
                 }
             ]


### PR DESCRIPTION
Do not open all footer links in a new tab

These links will now open in the same tab:

- Accessibility statement
- Cookies
- Terms and conditions
- Privacy notice

## What?

Please include a summary of the change.

## Why?

f a link opens in a new tab users of screen reading assistive technologies need to be provided with this information prior to activating the link. Either we update the link text to say that a new tab will open, or stop opening links in a new tab.

Four links will now open in the same tab as they lead to simple, more or less static pages, so using the back button will not cause any issues. The 'Support' link leads to a more complex page with more steps so it's best to keep this opening in a new tab, in this case the link text has been updated.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/664
