### PR TITLE
AUT-198: Add cookie which tracks manual logout

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -67,6 +67,7 @@ export const PATH_DATA: {
   },
   AUTH_CALLBACK: { url: "/auth/callback" },
   SESSION_EXPIRED: { url: "/session-expired" },
+  USER_SIGNED_OUT: { url: "/signed-out" },
   SIGN_OUT: { url: "/sign-out" },
   START: { url: "/" },
   HEALTHCHECK: { url: "/healthcheck" },

--- a/src/app.ts
+++ b/src/app.ts
@@ -50,6 +50,7 @@ import { deleteAccountRouter } from "./components/delete-account/delete-account-
 import { checkYourPhoneRouter } from "./components/check-your-phone/check-your-phone-routes";
 import { noCacheMiddleware } from "./middleware/no-cache-middleware";
 import { sessionExpiredRouter } from "./components/session-expired/session-expired-routes";
+import { signedOutRouter } from "./components/signed-out/signed-out-routes";
 import { setLocalVarsMiddleware } from "./middleware/set-local-vars-middleware";
 import { healthcheckRouter } from "./components/healthcheck/healthcheck-routes";
 import { globalLogoutRouter } from "./components/global-logout/global-logout-routes";
@@ -146,6 +147,7 @@ async function createApp(): Promise<express.Application> {
   app.use(deleteAccountRouter);
   app.use(checkYourPhoneRouter);
   app.use(sessionExpiredRouter);
+  app.use(signedOutRouter);
 
   app.use(logErrorMiddleware);
   app.use(serverErrorHandler);

--- a/src/components/logout/logout-controller.ts
+++ b/src/components/logout/logout-controller.ts
@@ -3,5 +3,6 @@ import { Request, Response } from "express";
 export async function logoutGet(req: Request, res: Response): Promise<void> {
   const idToken = req.session.user.tokens.idToken;
   req.session.destroy();
+  res.cookie('lo', 'true');
   res.redirect(req.oidc.endSessionUrl({ id_token_hint: idToken }));
 }

--- a/src/components/logout/logout-controller.ts
+++ b/src/components/logout/logout-controller.ts
@@ -3,6 +3,6 @@ import { Request, Response } from "express";
 export async function logoutGet(req: Request, res: Response): Promise<void> {
   const idToken = req.session.user.tokens.idToken;
   req.session.destroy();
-  res.cookie('lo', 'true');
+  res.cookie("lo", "true");
   res.redirect(req.oidc.endSessionUrl({ id_token_hint: idToken }));
 }

--- a/src/components/logout/tests/logout-controller.test.ts
+++ b/src/components/logout/tests/logout-controller.test.ts
@@ -32,7 +32,7 @@ describe("logout controller", () => {
   });
 
   describe("logoutGet", () => {
-    it.only("should redirect to end session url and set cookie", () => {
+    it("should redirect to end session url and set cookie", () => {
       req.session.user.tokens = {
         idToken: "id-token",
       };

--- a/src/components/logout/tests/logout-controller.test.ts
+++ b/src/components/logout/tests/logout-controller.test.ts
@@ -2,13 +2,12 @@ import { expect } from "chai";
 import { describe } from "mocha";
 
 import { sinon } from "../../../../test/utils/test-utils";
-import { Request, Response } from "express";
 import { logoutGet } from "../logout-controller";
 
 describe("logout controller", () => {
   let sandbox: sinon.SinonSandbox;
-  let req: Partial<Request>;
-  let res: Partial<Response>;
+  let req: any;
+  let res: any;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -17,7 +16,15 @@ describe("logout controller", () => {
       session: { user: {} },
       oidc: { endSessionUrl: sandbox.fake() },
     };
-    res = { render: sandbox.fake(), redirect: sandbox.fake(), locals: {} };
+    res = {
+      render: sandbox.fake(),
+      redirect: sandbox.fake(),
+      locals: {},
+      mockCookies: {},
+      cookie: function (name: string, value: string) {
+        this.mockCookies[name] = value;
+      },
+    };
   });
 
   afterEach(() => {
@@ -25,18 +32,19 @@ describe("logout controller", () => {
   });
 
   describe("logoutGet", () => {
-    it("should redirect to end session url", () => {
+    it.only("should redirect to end session url and set cookie", () => {
       req.session.user.tokens = {
         idToken: "id-token",
       };
 
       req.session.destroy = sandbox.fake();
 
-      logoutGet(req as Request, res as Response);
+      logoutGet(req, res);
 
       expect(res.redirect).to.have.called;
       expect(req.session.destroy).to.have.been.calledOnce;
       expect(req.oidc.endSessionUrl).to.have.been.calledOnce;
+      expect(res.mockCookies.lo).to.equal("true");
     });
   });
 });

--- a/src/components/signed-out/index.njk
+++ b/src/components/signed-out/index.njk
@@ -1,0 +1,20 @@
+{% extends "common/layout/base-page.njk" %}
+{% set hideSignOutLink = hideSignoutLink %}
+{% set pageTitleName = 'pages.signedOut.title' | translate %}
+
+{% block content %}
+
+<input type="hidden" name="_csrf" value="{{csrfToken}}" />
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signedOut.header' | translate }}</h1>
+
+<p class="govuk-body">
+  {{'pages.signedOut.paragraph1' | translate}} <a href="{{signinLink}}" class="govuk-link">{{'pages.signedOut.signInLinkText' | translate}}</a>.
+</p>
+
+<p class="govuk-body">
+ {{'pages.signedOut.paragraph2' | translate}} <a href="{{'pages.signedOut.govukLinkHref' | translate}}" class="govuk-link">{{'pages.signedOut.govukLinkText' | translate}}</a>.
+</p>
+
+{% endblock %}
+

--- a/src/components/signed-out/signed-out-controller.ts
+++ b/src/components/signed-out/signed-out-controller.ts
@@ -1,0 +1,10 @@
+import { Request, Response } from "express";
+import { PATH_DATA } from "../../app.constants";
+
+export function signedOutGet(_req: Request, res: Response): void {
+  res.status(401);
+  res.render("signed-out/index.njk", {
+    signinLink: PATH_DATA.START.url,
+    hideSignoutLink: true,
+  });
+}

--- a/src/components/signed-out/signed-out-routes.ts
+++ b/src/components/signed-out/signed-out-routes.ts
@@ -1,0 +1,10 @@
+import { PATH_DATA } from "../../app.constants";
+
+import express from "express";
+import { signedOutGet } from "./signed-out-controller";
+
+const router = express.Router();
+
+router.get(PATH_DATA.USER_SIGNED_OUT.url, signedOutGet);
+
+export { router as signedOutRouter };

--- a/src/components/signed-out/tests/signed-out-controller.test.ts
+++ b/src/components/signed-out/tests/signed-out-controller.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { signedOutGet } from "../signed-out-controller";
+
+describe("signed out controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+    };
+    res = {
+      render: sandbox.fake(),
+      status: sandbox.fake(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("signedOutGet", () => {
+    it.only("should return signed out page", () => {
+      signedOutGet(req as Request, res as Response);
+
+      expect(res.render).to.have.been.calledWith("signed-out/index.njk");
+      expect(res.status).to.have.be.calledWith(401);
+    });
+  });
+});

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -308,6 +308,15 @@
           "internationalFormat": "Enter a phone number in the correct format"
         }
       }
+    },
+    "signedOut": {
+      "title": "You have signed out",
+      "header": "You have signed out",
+      "paragraph1": "To go back, ",
+      "signInLinkText": "sign in to your GOV.UK account",
+      "paragraph2": "Or ",
+      "govukLinkText": "go to the GOV.UK homepage",
+      "govukLinkHref": "https://www.gov.uk/"
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -308,6 +308,15 @@
           "internationalFormat": "Enter a phone number in the correct format"
         }
       }
+    },
+    "signedOut": {
+      "title": "You have signed out",
+      "header": "You have signed out",
+      "paragraph1": "To go back, ",
+      "signInLinkText": "sign in to your GOV.UK account",
+      "paragraph2": "Or ",
+      "govukLinkText": "go to the GOV.UK homepage",
+      "govukLinkHref": "https://www.gov.uk/"
     }
   }
 }

--- a/src/middleware/requires-auth-middleware.ts
+++ b/src/middleware/requires-auth-middleware.ts
@@ -6,11 +6,15 @@ export function requiresAuthMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  const isLoggedIn = req.session.user && req.session.user.isAuthenticated;
+  const isAuthenticated = req.session.user?.isAuthenticated;
+  const isLoggedOut = req.cookies.lo;
 
-  if (!isLoggedIn) {
+  if (!isAuthenticated && isLoggedOut == "true") {
+    return res.redirect(req.oidc.endSessionUrl());
+  } else if (!isAuthenticated) {
     return res.redirect(PATH_DATA.SESSION_EXPIRED.url);
+  } else {
+    res.cookie("lo", "false");
+    next();
   }
-
-  next();
 }

--- a/src/middleware/requires-auth-middleware.ts
+++ b/src/middleware/requires-auth-middleware.ts
@@ -7,7 +7,7 @@ export function requiresAuthMiddleware(
   next: NextFunction
 ): void {
   const isAuthenticated = req.session.user?.isAuthenticated;
-  const isLoggedOut = req.cookies.lo;
+  const isLoggedOut = req.cookies?.lo;
 
   if (!isAuthenticated && isLoggedOut == "true") {
     return res.redirect(req.oidc.endSessionUrl());

--- a/src/middleware/requires-auth-middleware.ts
+++ b/src/middleware/requires-auth-middleware.ts
@@ -10,7 +10,7 @@ export function requiresAuthMiddleware(
   const isLoggedOut = req.cookies?.lo;
 
   if (!isAuthenticated && isLoggedOut == "true") {
-    return res.redirect(req.oidc.endSessionUrl());
+    return res.redirect(PATH_DATA.USER_SIGNED_OUT.url);
   } else if (!isAuthenticated) {
     return res.redirect(PATH_DATA.SESSION_EXPIRED.url);
   } else {

--- a/test/unit/middleware/requires-auth-middleware.test.ts
+++ b/test/unit/middleware/requires-auth-middleware.test.ts
@@ -5,17 +5,10 @@ import { sinon } from "../../utils/test-utils";
 import { requiresAuthMiddleware } from "../../../src/middleware/requires-auth-middleware";
 import { PATH_DATA } from "../../../src/app.constants";
 
-const MOCK_END_SESSION_URL = "mock end session url";
-
 describe("Requires auth middleware", () => {
   it("should redirect to signed out page if user logged out", () => {
     const req: any = {
       session: {},
-      oidc: {
-        endSessionUrl: function () {
-          return MOCK_END_SESSION_URL;
-        },
-      },
       cookies: {
         lo: "true",
       },
@@ -26,7 +19,7 @@ describe("Requires auth middleware", () => {
 
     requiresAuthMiddleware(req, res, nextFunction);
 
-    expect(res.redirect).to.have.been.calledWith(MOCK_END_SESSION_URL);
+    expect(res.redirect).to.have.been.calledWith(PATH_DATA.USER_SIGNED_OUT.url);
     expect(nextFunction).to.have.not.been.called;
   });
 

--- a/test/unit/middleware/requires-auth-middleware.test.ts
+++ b/test/unit/middleware/requires-auth-middleware.test.ts
@@ -3,9 +3,34 @@ import { describe } from "mocha";
 import { NextFunction } from "express";
 import { sinon } from "../../utils/test-utils";
 import { requiresAuthMiddleware } from "../../../src/middleware/requires-auth-middleware";
+import { PATH_DATA } from "../../../src/app.constants";
+
+const MOCK_END_SESSION_URL = "mock end session url";
 
 describe("Requires auth middleware", () => {
-  it("should redirect to start if user not authenticated", () => {
+  it("should redirect to signed out page if user logged out", () => {
+    const req: any = {
+      session: {},
+      oidc: {
+        endSessionUrl: function () {
+          return MOCK_END_SESSION_URL;
+        },
+      },
+      cookies: {
+        lo: "true",
+      },
+    };
+
+    const res: any = { locals: {}, redirect: sinon.fake() };
+    const nextFunction: NextFunction = sinon.fake();
+
+    requiresAuthMiddleware(req, res, nextFunction);
+
+    expect(res.redirect).to.have.been.calledWith(MOCK_END_SESSION_URL);
+    expect(nextFunction).to.have.not.been.called;
+  });
+
+  it("should redirect to session expired page if user not authenticated", () => {
     const req: any = {
       session: {
         user: {
@@ -20,18 +45,18 @@ describe("Requires auth middleware", () => {
 
     requiresAuthMiddleware(req, res, nextFunction);
 
-    expect(res.redirect).to.have.been.calledOnce;
+    expect(res.redirect).to.have.been.calledWith(PATH_DATA.SESSION_EXPIRED.url);
     expect(nextFunction).to.have.not.been.called;
   });
 
-  it("should redirect to start if no user session", () => {
+  it("should redirect to session expired page if no user session", () => {
     const req: any = { session: {} };
     const res: any = { locals: {}, redirect: sinon.fake() };
     const nextFunction: NextFunction = sinon.fake();
 
     requiresAuthMiddleware(req, res, nextFunction);
 
-    expect(res.redirect).to.have.been.calledOnce;
+    expect(res.redirect).to.have.been.calledWith(PATH_DATA.SESSION_EXPIRED.url);
     expect(nextFunction).to.have.not.been.called;
   });
 
@@ -44,11 +69,44 @@ describe("Requires auth middleware", () => {
         },
       },
     };
-    const res: any = { locals: {}, redirect: sinon.fake() };
+    const res: any = {
+      locals: {},
+      redirect: sinon.fake(),
+      cookie: sinon.fake(),
+    };
     const nextFunction: NextFunction = sinon.fake();
 
     requiresAuthMiddleware(req, res, nextFunction);
 
     expect(nextFunction).to.have.been.calledOnce;
+  });
+
+  it("should call next and reset lo cookie to false if user is authenticated", () => {
+    const req: any = {
+      session: {
+        user: {
+          email: "test@test.com",
+          isAuthenticated: true,
+        },
+        cookies: {
+          lo: "true",
+        },
+      },
+    };
+
+    const res: any = {
+      locals: {},
+      redirect: sinon.fake(),
+      mockCookies: {},
+      cookie: function (name: string, value: string) {
+        this.mockCookies[name] = value;
+      },
+    };
+    const nextFunction: NextFunction = sinon.fake();
+
+    requiresAuthMiddleware(req, res, nextFunction);
+
+    expect(nextFunction).to.have.been.calledOnce;
+    expect(res.mockCookies.lo).to.equal("false");
   });
 });


### PR DESCRIPTION
## What?

- Add cookie called `lo` (short for logged_out -> used abbreviation for consistency with other cookie names) to logout controller
- Read the status of that cookie in requires auth middleware
- Change the logic in that middleware so that instead of always either passing to `next()` or routing to session expired, we can now also direct to a new signed out page, based on the ability the `lo` cookie gives to distinguish between the two situations in which there is not a valid session
- PR includes creation of that new `/signed-out` page - which is very similar to the sign-in journey's `/signed-out` page, but differs lightly (see below) hence the need for a new route/view rather than reusing the same URL as initially implemented:

**Existing signed-out page for frontend:**
<img width="972" alt="image" src="https://user-images.githubusercontent.com/106964077/178505468-a9e22a6b-cc09-4c8b-bab1-4985328eac2d.png">

**New proposed signed-out page specific to account-management.** 
Primary difference is wording around going 'back' and the fact that the sign-in link routes via the account management 'START' url:
<img width="967" alt="image" src="https://user-images.githubusercontent.com/106964077/178506468-4d8a3d05-d573-44b2-b57c-00fff56d460e.png">



## Why?

- This allows differentiation of active logout (redirecting user to generic sign-in screen) vs session timeout/expiry (redirecting user to a screen informing them of timeout).