### PR TITLE
AUT-557: change footer cookie href

### DIFF
--- a/src/components/common/layout/banner.njk
+++ b/src/components/common/layout/banner.njk
@@ -1,19 +1,23 @@
 {% set html %}
-    <p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph1' | translate }}</p>
-    <p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph2' | translate }}</p>
+<p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph1' | translate }}</p>
+<p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph2' | translate }}</p>
 {% endset %}
 
 {% set html %}
-    <p class="govuk-body" >We use some essential cookies to make this service work.</p>
-    <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
 {% endset %}
 
 {% set acceptHtml %}
-    <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="https://www.gov.uk/help/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
+<p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}
+    <a class="govuk-link" href="https://www.gov.uk/help/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a>
+    {{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
 {% endset %}
 
 {% set rejectedHtml %}
-    <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph1' | translate }}<a class="govuk-link" href="https://www.gov.uk/help/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph2' | translate }}</p>
+<p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph1' | translate }}
+    <a class="govuk-link" href="https://www.gov.uk/help/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a>
+    {{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph2' | translate }}</p>
 {% endset %}
 
 {{ govukCookieBanner({
@@ -41,7 +45,7 @@
             },
             {
                 text: "View cookies",
-                href: "https://www.gov.uk/help/cookies"
+                href: authFrontEndUrl + "/cookies"
             }
         ]
         },

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -9,14 +9,10 @@
 
     {# For Internet Explorer 8, you need to compile specific stylesheet #}
     {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
-    <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
-    <![endif]-->
+    <!--[if IE 8]> <link href="/govuk-frontend/all-ie8.css" rel="stylesheet"> <![endif]-->
 
     {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-    <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-    <![endif]-->
+    <!--[if lt IE 9]> <script src="/html5-shiv/html5shiv.js"></script> <![endif]-->
 
 {% endblock %}
 
@@ -37,13 +33,13 @@
 {% endblock %}
 
 {% block header %}
- {% if hideSignOutLink %}
-    {{ govukHeader({
+    {% if hideSignOutLink %}
+        {{ govukHeader({
            homepageUrl: 'general.header.homepageHref' | translate
        }) }}
 
-  {% else %}
-       {{ govukHeader({
+    {% else %}
+        {{ govukHeader({
            homepageUrl: 'general.header.homepageHref' | translate,
            navigationClasses: "govuk-header__navigation--end",
            navigation: [
@@ -58,7 +54,7 @@
                }
              ]
        }) }}
-  {% endif %}
+    {% endif %}
 
 {% endblock %}
 
@@ -72,10 +68,9 @@
         }) }}
         {% if backLink %}
             <a href="{{backLink}}" class="govuk-back-link">{{'general.back' | translate}}</a>
-         {% endif %}
+        {% endif %}
         {% block beforeContent %}{% endblock %}
-        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content"
-              role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main" {% if mainLang %} lang="{{ mainLang }}" {% endif %}>
             {% block content %}{% endblock %}
         </main>
     </div>
@@ -92,7 +87,7 @@
                     text: 'general.footer.accessibilityStatement.linkText' | translate
                 },
                 {
-                    href: "https://www.gov.uk/help/cookies",
+                    href: authFrontEndUrl + "/cookies",
                     text: 'general.footer.cookies.linkText' | translate
                 },
                 {
@@ -110,8 +105,12 @@
 
 {% block bodyEnd %}
     {% block scripts %}{% endblock %}
-  <script type="text/javascript" src="/public/scripts/cookies.js"></script>
-  <script type="text/javascript"  src="/public/scripts/application.js"></script>
-  <script type="text/javascript"  src="/public/scripts/all.js"></script>
-  <script type="text/javascript" nonce='{{scriptNonce}}'>window.GOVSignIn.appInit("{{gtmId}}", "{{ analyticsCookieDomain }}")</script>
+    <script type="text/javascript" src="/public/scripts/cookies.js"></script>
+    <script type="text/javascript" src="/public/scripts/application.js"></script>
+    <script type="text/javascript" src="/public/scripts/all.js"></script>
+    <script type="text/javascript" nonce='{{scriptNonce}}'>
+        window
+            .GOVSignIn
+            .appInit("{{gtmId}}", "{{ analyticsCookieDomain }}")
+    </script>
 {% endblock %}


### PR DESCRIPTION
## What?

- Change footer cookie href from generic gov.uk cookies to signin custom cookies page
- Change cookie banner 'view cookies' href from generic gov.uk cookies to signin custom cookies page

## Why?

- So that user has correct set of cookie information
