### PR TITLE
GUA-226: Update content on delete account page

### DIFF
--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -6,10 +6,12 @@ import { PATH_DATA } from "../../app.constants";
 import { getNextState } from "../../utils/state-machine";
 import { GovUkPublishingServiceInterface } from "../common/gov-uk-publishing/types";
 import { govUkPublishingService } from "../common/gov-uk-publishing/gov-uk-publishing-service";
-import { getBaseUrl } from "../../config";
+import { getBaseUrl, getManageGovukEmailsUrl } from "../../config";
 
 export function deleteAccountGet(req: Request, res: Response): void {
-  res.render("delete-account/index.njk");
+  res.render("delete-account/index.njk", {
+    manageEmailsLink: getManageGovukEmailsUrl()
+  });
 }
 
 export function deleteAccountPost(

--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -1,24 +1,34 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageTitleName = 'pages.deleteAccount.title' | translate %}
 
 {% block pageContent%}
 
 {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.deleteAccount.header' | translate}}</h1>
+<h1 class="govuk-heading-l govuk-!-margin-top-0">{{'pages.deleteAccount.header' | translate}}</h1>
 
-<br>
+<p class="govuk-body">{{'pages.deleteAccount.paragraph1' | translate}}</p>
 
-{{ govukWarningText({
-  text: 'pages.deleteAccount.warningText' | translate
+<ul class="govuk-list govuk-list--bullet">
+  <li>{{ 'pages.deleteAccount.listItem1' | translate }}</li>
+  <li>{{ 'pages.deleteAccount.listItem2'
+    | translate
+    | replace("[emailManagementLink]", manageEmailsLink)
+    | safe
+  }}</li>
+  <li>{{ 'pages.deleteAccount.listItem3' | translate }}</li>
+</ul>
+<p class="govuk-body">{{ 'pages.deleteAccount.paragraph2' | translate }}</p>
+<p class="govuk-body">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
+
+{{ govukDetails({
+  summaryText: 'pages.deleteAccount.details.summaryText' | translate,
+  html: 'pages.deleteAccount.details.text' | translate
 }) }}
-
-<p class="govuk-body">{{'pages.deleteAccount.paragraph' | translate}}</p>
 
 <form action="/delete-account" method="post" novalidate>
 
@@ -33,11 +43,8 @@
 
 </form>
 
-<br>
-
 <a href="/manage-your-account" class="govuk-link govuk-body">
-    {{'pages.deleteAccount.doNotDeleteAccount' | translate}}
+    {{ 'pages.deleteAccount.doNotDeleteAccount' | translate }}
 </a>
 
 {% endblock %}
-

--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% set pageTitleName = 'pages.manageYourAccount.title' | translate %}
 
-{% set govukSummaryListArgs = 
+{% set govukSummaryListArgs =
 {
     classes:"accounts-summary-list",
     rows: [
@@ -76,7 +76,7 @@
 
             <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.manageEmailSubscriptions.heading' | translate }}</h2>
             <p class="govuk-body">{{ 'pages.manageYourAccount.manageEmailSubscriptions.info' | translate }}</p>
-            <a href="https://www.gov.uk/email/manage" class="govuk-link govuk-body">{{ 'pages.manageYourAccount.manageEmailSubscriptions.link' | translate }}</a>
+            <a href="{{ manageEmailsLink }}" class="govuk-link govuk-body">{{ 'pages.manageYourAccount.manageEmailSubscriptions.link' | translate }}</a>
             <hr class="govuk-section-break govuk-section-break--m">
             <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.deleteAccount.heading' | translate }}</h2>
             <p class="govuk-body">{{ 'pages.manageYourAccount.deleteAccount.info' | translate }}</p>

--- a/src/components/manage-your-account/manage-your-account-controller.ts
+++ b/src/components/manage-your-account/manage-your-account-controller.ts
@@ -1,10 +1,12 @@
 import { Request, Response } from "express";
 import { redactPhoneNumber } from "../../utils/strings";
+import { getManageGovukEmailsUrl } from "../../config";
 
 export function manageYourAccountGet(req: Request, res: Response): void {
   const data = {
     email: req.session.user.email,
     phoneNumber: redactPhoneNumber(req.session.user.phoneNumber),
+    manageEmailsLink: getManageGovukEmailsUrl()
   };
 
   res.render("manage-your-account/index.njk", data);

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,6 +126,10 @@ export function getTokenValidationClockSkew(): number {
   return Number(process.env.TOKEN_CLOCK_SKEW) || 10;
 }
 
+export function getManageGovukEmailsUrl(): string {
+  return "https://www.gov.uk/email/manage";
+}
+
 function getProtocol(): string {
   return getAppEnv() !== "local" ? "https://" : "http://";
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -274,12 +274,20 @@
       }
     },
     "deleteAccount": {
-      "title": "Are you sure you want to delete your account?",
-      "header": "Are you sure you want to delete your account?",
-      "warningText": "Your account will be permanently deleted. You will not be able to get it back.",
-      "paragraph": "Deleting your GOV.UK account will not delete any other government accounts you have, such as Government Gateway or your Universal Credit account.",
-      "deleteAccount": "Delete account",
-      "doNotDeleteAccount": "I do not want to delete my account"
+      "title": "Are you sure you want to delete your GOV.UK account?",
+      "header": "Are you sure you want to delete your GOV.UK account?",
+      "paragraph1": "This will:",
+      "listItem1": "permanently delete your GOV.UK account and the information stored in it",
+      "listItem2": "delete any <a class=\"govuk-link\" href=\"[emailManagementLink]\">GOV.UK email subscriptions</a> you may have",
+      "listItem3": "remove your ability to sign in to LITE (to apply for export licences for controlled goods), if you’ve used it with your GOV.UK account",
+      "paragraph2": "If you need a GOV.UK account in the future, you’ll have to create a new one.",
+      "paragraph3": "Deleting your GOV.UK account will not delete any other government accounts you may have, such as Government Gateway or Universal Credit.",
+      "details": {
+        "summaryText": "If you use LITE",
+        "text": "<p class=\"govuk-body\">If you delete your GOV.UK account you will no longer be able to sign in to LITE (Licensing for International Trade and Enterprise).</p><p class=\"govuk-body\"> The information about you held in LITE will not be deleted. Email <a class=\"govuk-link\" href=\"mailto:data.protection@trade.gov.uk\">data.protection@trade.gov.uk</a> if you want to delete information held by LITE.</p>"
+      },
+      "deleteAccount": "Delete your GOV.UK account",
+      "doNotDeleteAccount": "Cancel and go back to your account"
     },
     "changePhoneNumber": {
       "title": "Enter your new mobile phone number",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -274,12 +274,20 @@
       }
     },
     "deleteAccount": {
-      "title": "Are you sure you want to delete your account?",
-      "header": "Are you sure you want to delete your account?",
-      "warningText": "Your account will be permanently deleted. You will not be able to get it back.",
-      "paragraph": "Deleting your GOV.UK account will not delete any other government accounts you have, such as Government Gateway or your Universal Credit account.",
-      "deleteAccount": "Delete account",
-      "doNotDeleteAccount": "I do not want to delete my account"
+      "title": "Are you sure you want to delete your GOV.UK account?",
+      "header": "Are you sure you want to delete your GOV.UK account?",
+      "paragraph1": "This will:",
+      "listItem1": "permanently delete your GOV.UK account and the information stored in it",
+      "listItem2": "delete any <a class=\"govuk-link\" href=\"[emailManagementLink]\">GOV.UK email subscriptions</a> you may have",
+      "listItem3": "remove your ability to sign in to LITE (to apply for export licences for controlled goods), if you’ve used it with your GOV.UK account",
+      "paragraph2": "If you need a GOV.UK account in the future, you’ll have to create a new one.",
+      "paragraph3": "Deleting your GOV.UK account will not delete any other government accounts you may have, such as Government Gateway or Universal Credit.",
+      "details": {
+        "summaryText": "If you use LITE",
+        "text": "<p class=\"govuk-body\">If you delete your GOV.UK account you will no longer be able to sign in to LITE (Licensing for International Trade and Enterprise).</p><p class=\"govuk-body\"> The information about you held in LITE will not be deleted. Email <a class=\"govuk-link\" href=\"mailto:data.protection@trade.gov.uk\">data.protection@trade.gov.uk</a> if you want to delete information held by LITE.</p>"
+      },
+      "deleteAccount": "Delete your GOV.UK account",
+      "doNotDeleteAccount": "Cancel and go back to your account"
     },
     "changePhoneNumber": {
       "title": "Enter your new mobile phone number",


### PR DESCRIPTION
~**This can be reviewed but please do not merge yet, we will deploy this once we hear from LITE regarding the exact date/time they are going live (due to onboard 25 July, but there’s a chance there might be delays).**~
LITE have gone live with GOV.UK Sign In so we can go ahead. 🚀 

## What?

Update content of 'Are you sure you want to delete your account' screen ahead of LITE service onboarding.

Design is here: https://www.figma.com/file/tepd26ZAc8QhiLJlxYN1wR/Data-management-and-Navigation?node-id=1522%3A3976

### Before 
<img width="1674" alt="Screenshot 2022-07-21 at 13 55 22" src="https://user-images.githubusercontent.com/7116819/180403803-7a393539-cc0c-42bd-882d-6084e6e15fd6.png">

### After 
<img width="1671" alt="Screenshot 2022-07-22 at 09 58 58" src="https://user-images.githubusercontent.com/7116819/180403815-435c39ce-8788-4104-b491-0d372a322f42.png">





## Why?
The purpose of these updates is so that the page more clearly explains the consequences of deleting your account.
