### PR TITLE
AUT-588: Display only verified phone numbers in account management

### DIFF
--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -42,7 +42,7 @@
             }
 ]} %}
 
-{% if phoneNumber %}
+{% if isPhoneNumberVerified %}
     {% set govukSummaryListArgs = (govukSummaryListArgs.rows.push(            {
                 key: {
                     text: 'pages.manageYourAccount.summaryList.phoneNumber' | translate

--- a/src/components/manage-your-account/manage-your-account-controller.ts
+++ b/src/components/manage-your-account/manage-your-account-controller.ts
@@ -6,7 +6,8 @@ export function manageYourAccountGet(req: Request, res: Response): void {
   const data = {
     email: req.session.user.email,
     phoneNumber: redactPhoneNumber(req.session.user.phoneNumber),
-    manageEmailsLink: getManageGovukEmailsUrl()
+    isPhoneNumberVerified: req.session.user.isPhoneNumberVerified,
+    manageEmailsLink: getManageGovukEmailsUrl(),
   };
 
   res.render("manage-your-account/index.njk", data);

--- a/src/components/manage-your-account/tests/manage-your-account-integration.test.ts
+++ b/src/components/manage-your-account/tests/manage-your-account-integration.test.ts
@@ -10,6 +10,7 @@ const TEST_USER_PHONE_NUMBER = "07839490040";
 const DEFAULT_USER_SESSION = {
   email: TEST_USER_EMAIL,
   phoneNumber: TEST_USER_PHONE_NUMBER,
+  isPhoneNumberVerified: true,
   isAuthenticated: true,
   state: {},
   tokens: {
@@ -43,10 +44,15 @@ describe("Integration:: manage your account", () => {
   });
 
   it("should not attempt to display phone number when none is known", async () => {
-    const { phoneNumber, ...nonPhoneSessionProperties } = DEFAULT_USER_SESSION; // eslint-disable-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { isPhoneNumberVerified, ...nonIsPhoneVerifiedSessionProperties } =
+      DEFAULT_USER_SESSION;
 
     const app = await appWithMiddlewareSetup({
-      customUserSession: nonPhoneSessionProperties,
+      customUserSession: {
+        ...nonIsPhoneVerifiedSessionProperties,
+        isPhoneNumberVerified: false,
+      },
     });
 
     await request(app)

--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -82,6 +82,7 @@ export function oidcAuthCallbackGet(
     req.session.user = {
       email: userInfoResponse.email,
       phoneNumber: userInfoResponse.phone_number,
+      isPhoneNumberVerified: userInfoResponse.phone_number_verified,
       subjectId: userInfoResponse.sub,
       legacySubjectId: userInfoResponse.legacy_subject_id,
       tokens: {


### PR DESCRIPTION
## What?
- Refactor callback controller to save `phone_number_verified` field of UserInfo response to the session user data
- Use this new field in the session user data as the basis for conditional display logic to either show or not show a phone number in account management screen

- Note: This conditional display logic was previously being done on the basis of simple existence of a phone number. However, that meant the row would be displayed even if not verified.

Screen when phone number IS verified:
<img width="995" alt="image" src="https://user-images.githubusercontent.com/106964077/182831253-e5b8aa1c-fdcc-4842-bb61-cd258a9fa47a.png">


Screen when phone number IS NOT verified:
<img width="982" alt="image" src="https://user-images.githubusercontent.com/106964077/182830775-d3d97b48-1bee-488c-b2df-f81fd47072b1.png">


## Why?

Unverified phone numbers were previously being displayed. This was particularly undesirable when a user saved a phone number record during account creation, then changed mind on MFA method to use auth app instead. In this case, we would not want the phone number to display on the account management screen, but it would, because the phone number would still exist in the account record - simply it wouldn't be verified.

## Related PRs

Corrects bug introduced in my earlier PR here (the conditional display logic based on phone number existing): 
