### PR TITLE
Add container_name to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - 6379:6379
 
   di-auth-account-management-frontend:
+    container_name: di-auth-account-management-frontend-dev
     build:
       context: .
       dockerfile: local.Dockerfile


### PR DESCRIPTION
## What?

Add `container_name` to docker-compose.yml

## Why?

Allows `docker exec` to run against container name rather than ID as is shown in the "Running the tests" section of README.md