### PR TITLE
AUT-554: Make govukInput elements numeric for OTP code

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -9,23 +9,23 @@
 
 {% block pageContent %}
 
-{% include "common/errors/errorSummary.njk" %}
+    {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourEmail.header' | translate}}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourEmail.header' | translate}}</h1>
 
-{{ govukInsetText({
+    {{ govukInsetText({
     html: 'pages.checkYourEmail.text' | translate + '<span class="govuk-body govuk-!-font-weight-bold">' + email + '</span>'
   }) }}
 
-<p class="govuk-body">{{'pages.checkYourEmail.info.paragraph1' | translate}}</p>
-<p class="govuk-body">{{'pages.checkYourEmail.info.paragraph2' | translate}}</p>
-<p class="govuk-body">{{'pages.checkYourEmail.info.paragraph3' | translate }}</p>
+    <p class="govuk-body">{{'pages.checkYourEmail.info.paragraph1' | translate}}</p>
+    <p class="govuk-body">{{'pages.checkYourEmail.info.paragraph2' | translate}}</p>
+    <p class="govuk-body">{{'pages.checkYourEmail.info.paragraph3' | translate }}</p>
 
-<form action="/check-your-email" method="post" novalidate>
+    <form action="/check-your-email" method="post" novalidate="novalidate">
 
-<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-<input type="hidden" name="email" value="{{email}}"/>
-{{ govukInput({
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <input type="hidden" name="email" value="{{email}}"/>
+        {{ govukInput({
     label: {
         text: 'pages.checkYourEmail.code.label' | translate
     },
@@ -33,28 +33,28 @@
     id: "code",
     name: "code",
     value: code,
+    inputmode: "numeric",
+    pattern: "[0-9]*",
+    spellcheck: false,
     errorMessage: {
         text: errors['code'].text
     } if (errors['code'])})
 }}
 
-
-
-{{ govukButton({
+        {{ govukButton({
     "text": button_text|default("Continue", true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}
 
-</form>
-<p class="govuk-body">
-<a href="/request-new-email-code" class="govuk-link govuk-body" rel="noreferrer noopener">{{'pages.checkYourEmail.info.requestNewCodeLink' | translate }}</a> {{'pages.checkYourEmail.info.requestNewCodeParagraph' | translate }}
-</p>
+    </form>
+    <p class="govuk-body">
+        <a href="/request-new-email-code" class="govuk-link govuk-body" rel="noreferrer noopener">{{'pages.checkYourEmail.info.requestNewCodeLink' | translate }}</a>
+        {{'pages.checkYourEmail.info.requestNewCodeParagraph' | translate }}
+    </p>
 
-  <ul class="govuk-list govuk-list--bullet">
-      <li>{{ 'pages.checkYourEmail.info.requestNewCodeReason1' | translate}}</li>
-      <li>{{ 'pages.checkYourEmail.info.requestNewCodeReason2' | translate}}</li>
-     </ul>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.checkYourEmail.info.requestNewCodeReason1' | translate}}</li>
+        <li>{{ 'pages.checkYourEmail.info.requestNewCodeReason2' | translate}}</li>
+    </ul>
 {% endblock %}
-
-

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -9,19 +9,19 @@
 
 {% block pageContent %}
 
-{% include "common/errors/errorSummary.njk" %}
+    {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate}}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate}}</h1>
 
-<p class="govuk-body">{{'pages.checkYourPhone.text' | translate | replace("[mobile]", phoneNumber )}}</p>
+    <p class="govuk-body">{{'pages.checkYourPhone.text' | translate | replace("[mobile]", phoneNumber )}}</p>
 
-<p class="govuk-body">{{'pages.checkYourPhone.info.paragraph' | translate}}</p>
+    <p class="govuk-body">{{'pages.checkYourPhone.info.paragraph' | translate}}</p>
 
-<form action="/check-your-phone" method="post" novalidate>
+    <form action="/check-your-phone" method="post" novalidate="novalidate">
 
-<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-<input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
-{{ govukInput({
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+        {{ govukInput({
     label: {
         text: 'pages.checkYourPhone.code.label' | translate
     },
@@ -29,24 +29,28 @@
     id: "code",
     name: "code",
     value: code,
+    inputmode: "numeric",
+    pattern: "[0-9]*",
+    spellcheck: false,
     errorMessage: {
         text: errors['code'].text
     } if (errors['code'])})
 }}
 
-{{ govukButton({
+        {{ govukButton({
     "text": button_text|default("Continue", true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}
 
-</form>
-<p class="govuk-body">
-<a href="/request-new-opt-code" class="govuk-link govuk-body" rel="noreferrer noopener">{{'pages.checkYourPhone.info.requestNewCodeLink' | translate }}</a> {{'pages.checkYourPhone.info.requestNewCodeParagraph' | translate }}
-</p>
+    </form>
+    <p class="govuk-body">
+        <a href="/request-new-opt-code" class="govuk-link govuk-body" rel="noreferrer noopener">{{'pages.checkYourPhone.info.requestNewCodeLink' | translate }}</a>
+        {{'pages.checkYourPhone.info.requestNewCodeParagraph' | translate }}
+    </p>
 
-  <ul class="govuk-list govuk-list--bullet">
-      <li>{{ 'pages.checkYourPhone.info.requestNewCodeReason1' | translate}}</li>
-      <li>{{ 'pages.checkYourPhone.info.requestNewCodeReason2' | translate}}</li>
-     </ul>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.checkYourPhone.info.requestNewCodeReason1' | translate}}</li>
+        <li>{{ 'pages.checkYourPhone.info.requestNewCodeReason2' | translate}}</li>
+    </ul>
 {% endblock %}


### PR DESCRIPTION
## What?

- Add fields to all govukInput elements which take an OTP code
- Make input mode numeric and pattern match for "[0-9]*"
- This is instead of <input type="number"> which can be increased accidentally with keyboard arrows or scroll wheel

## Why?

- So that users are less likely to submit an incorrect OTP code simply by having knocked their mouse or keyboard and therefore changing their input without noticing

## Related PRs

Same thing for frontend: https://github.com/alphagov/di-authentication-frontend/pull/723
