### PR TITLE
BAU: Bump govuk-frontend from 4.0.1 to 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.2",
     "express-validator": "^6.13.0",
-    "govuk-frontend": "^4.0.1",
+    "govuk-frontend": "^4.3.1",
     "helmet": "4.6.0",
     "i18next": "^21.5.4",
     "i18next-fs-backend": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,10 +2071,10 @@ globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-govuk-frontend@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.0.1.tgz#bceff58ecb399272cba32bd2b357fe16198e3249"
-  integrity sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==
+govuk-frontend@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.3.1.tgz#d9c581aca3d23bbfe9bd27c25fee65322b276393"
+  integrity sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==
 
 graceful-fs@^4.1.15:
   version "4.2.8"


### PR DESCRIPTION
## What?

- Bump govuk-frontend from 4.0.1 to 4.3.1

## Why?

- Will allow copyright statement to be translated into Welsh (see release notes: https://github.com/alphagov/govuk-frontend/releases/tag/v4.3.0)

