### PR TITLE
AUT-607: Limit SMS OTP attempts, frontend changes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -56,6 +56,7 @@ import { healthcheckRouter } from "./components/healthcheck/healthcheck-routes";
 import { globalLogoutRouter } from "./components/global-logout/global-logout-routes";
 import { subjectSessionIndex } from "./utils/subject-session-index";
 import { subjectSessionIndexMiddleware } from "./middleware/subject-session-index-middleware";
+import { securityCodeErrorRouter } from "./components/security-code-error/security-code-error-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -147,6 +148,7 @@ async function createApp(): Promise<express.Application> {
   app.use(deleteAccountRouter);
   app.use(checkYourPhoneRouter);
   app.use(sessionExpiredRouter);
+  app.use(securityCodeErrorRouter);
   app.use(signedOutRouter);
 
   app.use(logErrorMiddleware);

--- a/src/components/check-your-phone/check-your-phone-service.ts
+++ b/src/components/check-your-phone/check-your-phone-service.ts
@@ -1,6 +1,7 @@
-import { getRequestConfig, Http, http } from "../../utils/http";
+import { createApiResponse, getRequestConfig, Http, http } from "../../utils/http";
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
 import { CheckYourPhoneServiceInterface } from "./types";
+import {ApiResponseResult} from "../../utils/types";
 
 export function checkYourPhoneService(
   axios: Http = http
@@ -13,8 +14,8 @@ export function checkYourPhoneService(
     sourceIp: string,
     sessionId: string,
     persistentSessionId: string
-  ): Promise<boolean> {
-    const { status } = await axios.client.post<void>(
+  ): Promise<ApiResponseResult> {
+    const response = await axios.client.post<void>(
       API_ENDPOINTS.UPDATE_PHONE_NUMBER,
       {
         email,
@@ -30,7 +31,7 @@ export function checkYourPhoneService(
       )
     );
 
-    return status === HTTP_STATUS_CODES.NO_CONTENT;
+    return createApiResponse(response, [HTTP_STATUS_CODES.NO_CONTENT]);
   };
 
   return {

--- a/src/components/check-your-phone/types.ts
+++ b/src/components/check-your-phone/types.ts
@@ -1,3 +1,5 @@
+import {ApiResponseResult} from "../../utils/types";
+
 export interface CheckYourPhoneServiceInterface {
   updatePhoneNumber: (
     accessToken: string,
@@ -7,5 +9,5 @@ export interface CheckYourPhoneServiceInterface {
     sourceIp: string,
     sessionId: string,
     persistentSessionId: string
-  ) => Promise<boolean>;
+  ) => Promise<ApiResponseResult>;
 }

--- a/src/components/security-code-error/index.njk
+++ b/src/components/security-code-error/index.njk
@@ -1,0 +1,16 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'pages.securityCodeInvalid.title' | translate %}
+
+{% block content %}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeInvalid.header' | translate }}</h1>
+
+<p class="govuk-body">{{'pages.securityCodeInvalid.info.paragraph1' | translate}}</p>
+<p class="govuk-body">
+    {{'pages.securityCodeInvalid.info.paragraph2Start' | translate}}
+    <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.info.link' | translate}}</a>
+    {{'pages.securityCodeInvalid.info.paragraph2End' | translate}}
+</p>
+
+{% endblock %} 

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from "express";
+import { PATH_DATA } from "../../app.constants";
+
+export function securityCodeInvalidGet(req: Request, res: Response): void {
+  res.render("security-code-error/index.njk", {
+    newCodeLink: PATH_DATA.RESEND_MFA_CODE,
+  });
+}

--- a/src/components/security-code-error/security-code-error-routes.ts
+++ b/src/components/security-code-error/security-code-error-routes.ts
@@ -1,0 +1,19 @@
+import { PATH_DATA } from "../../app.constants"
+
+import * as express from "express";
+import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
+import {
+  securityCodeInvalidGet,
+} from "./security-code-error-controller";
+
+const router = express.Router();
+
+router.get(
+    PATH_DATA.SECURITY_CODE_INVALID.url,
+    requiresAuthMiddleware,
+    securityCodeInvalidGet
+);
+
+
+
+export { router as securityCodeErrorRouter };

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+
+import { securityCodeInvalidGet } from "../security-code-error-controller";
+import { Request, Response } from "express";
+import { SecurityCodeErrorType } from "../../../app.constants";
+
+describe("security code  controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    req = {
+        body: {},
+        session: { user: { state: { securityCodeError: {} } } },
+        i18n: { language: "" },
+        t: sandbox.fake(),
+        query: {},
+      };
+      res = {
+        render: sandbox.fake(),
+        redirect: sandbox.fake(),
+        locals: {},
+        status: sandbox.fake(),
+      };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("securityCodeExpiredGet", () => {
+    it("should render security code expired view", () => {
+      req.query.actionType = SecurityCodeErrorType.OtpMaxCodesSent;
+
+      securityCodeInvalidGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("security-code-error/index.njk");
+    });
+  });
+});

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -325,6 +325,16 @@
       "paragraph2": "Or ",
       "govukLinkText": "go to the GOV.UK homepage",
       "govukLinkHref": "https://www.gov.uk/"
+    },
+    "securityCodeInvalid": {
+      "title": "You entered the wrong security code too many times",
+      "header": "You entered the wrong security code too many times",
+      "info": {
+        "paragraph1": "You need to wait 15 minutes.",
+        "paragraph2Start": "You can then ",
+        "link": "get a new code",
+        "paragraph2End": " and try again."
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -325,6 +325,16 @@
       "paragraph2": "Or ",
       "govukLinkText": "go to the GOV.UK homepage",
       "govukLinkHref": "https://www.gov.uk/"
+    },
+    "securityCodeInvalid": {
+      "title": "You entered the wrong security code too many times",
+      "header": "You entered the wrong security code too many times",
+      "info": {
+        "paragraph1": "You need to wait 15 minutes.",
+        "paragraph2Start": "You can then ",
+        "link": "get a new code",
+        "paragraph2End": " and try again."
+      }
     }
   }
 }


### PR DESCRIPTION
## What?

Build new security code error page to display error message when SMS OTP attempts limits are exceeded.

## Why?

Limit SMS OTP attempts for users when changing a phone number

## Related PRs

[Backend changes](https://github.com/alphagov/di-authentication-account-management/pull/561)
