### PR TITLE
AUT-599: update "Check your email" to reflect Figma

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -7,6 +7,8 @@
 
 {% set pageTitleName = 'pages.checkYourEmail.title' | translate %}
 
+{% set backLink = 'pages.checkYourEmail.changeEmailLinkHref' | translate %}
+
 {% block pageContent %}
 
 {% include "common/errors/errorSummary.njk" %}
@@ -45,7 +47,7 @@
         {{'pages.checkYourEmail.details.text1' | translate}}
         <a href="{{'pages.checkYourEmail.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourEmail.details.sendCodeLinkText' | translate }}</a>
         {{'pages.checkYourEmail.details.text2' | translate}}
-        <a href="{{'pages.checkYourEmail.details.changeEmailLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourEmail.details.changeEmailLinkText'| translate}}</a>.
+        <a href="{{'pages.checkYourEmail.changeEmailLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourEmail.details.changeEmailLinkText'| translate}}</a>.
     </p>
 {% endset %}
 

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -9,23 +9,23 @@
 
 {% block pageContent %}
 
-    {% include "common/errors/errorSummary.njk" %}
+{% include "common/errors/errorSummary.njk" %}
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourEmail.header' | translate}}</h1>
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourEmail.header' | translate}}</h1>
 
-    {{ govukInsetText({
+{{ govukInsetText({
     html: 'pages.checkYourEmail.text' | translate + '<span class="govuk-body govuk-!-font-weight-bold">' + email + '</span>'
   }) }}
 
-    <p class="govuk-body">{{'pages.checkYourEmail.info.paragraph1' | translate}}</p>
-    <p class="govuk-body">{{'pages.checkYourEmail.info.paragraph2' | translate}}</p>
-    <p class="govuk-body">{{'pages.checkYourEmail.info.paragraph3' | translate }}</p>
+<p class="govuk-body">{{'pages.checkYourEmail.info.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.checkYourEmail.info.paragraph2' | translate}}</p>
+<p class="govuk-body">{{'pages.checkYourEmail.info.paragraph3' | translate }}</p>
 
-    <form action="/check-your-email" method="post" novalidate="novalidate">
+<form action="/check-your-email" method="post" novalidate="novalidate">
 
-        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-        <input type="hidden" name="email" value="{{email}}"/>
-        {{ govukInput({
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="email" value="{{email}}"/>
+{{ govukInput({
     label: {
         text: 'pages.checkYourEmail.code.label' | translate
     },
@@ -40,20 +40,28 @@
     } if (errors['code'])})
 }}
 
-        {{ govukButton({
+{% set detailsHTML %}
+    <p class="govuk-body">
+        {{'pages.checkYourEmail.details.text1' | translate}}
+        <a href="{{'pages.checkYourEmail.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourEmail.details.sendCodeLinkText' | translate }}</a>
+        {{'pages.checkYourEmail.details.text2' | translate}}
+        <a href="{{'pages.checkYourEmail.details.changeEmailLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourEmail.details.changeEmailLinkText'| translate}}</a>.
+    </p>
+{% endset %}
+
+{{ govukDetails({
+    summaryText: 'pages.checkYourEmail.details.summaryText' | translate,
+    html: detailsHTML
+}) }}
+
+{{ govukButton({
     "text": button_text|default("Continue", true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}
 
-    </form>
-    <p class="govuk-body">
-        <a href="/request-new-email-code" class="govuk-link govuk-body" rel="noreferrer noopener">{{'pages.checkYourEmail.info.requestNewCodeLink' | translate }}</a>
-        {{'pages.checkYourEmail.info.requestNewCodeParagraph' | translate }}
-    </p>
+</form>
 
-    <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.checkYourEmail.info.requestNewCodeReason1' | translate}}</li>
-        <li>{{ 'pages.checkYourEmail.info.requestNewCodeReason2' | translate}}</li>
-    </ul>
 {% endblock %}
+
+

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -231,14 +231,19 @@
       "title": "Gwiriwch eich e-bost",
       "header": "Gwiriwch eich e-bost",
       "text": "Rydym wedi anfon e-bost at: ",
+      "changeEmailLinkHref": "/change-email",
+      "details": {
+        "summaryText": "Problemau gyda'r cod?",
+        "text1": "Gallwn ",
+        "sendCodeLinkText": "anfon y cod eto",
+        "sendCodeLinkHref": "/request-new-email-code",
+        "text2": " neu gallwch ",
+        "changeEmailLinkText": "ddefnyddio cyfeiriad e-bost gwahanol"
+      },
       "info": {
         "paragraph1": "Mae'r e-bost yn cynnwys cod diogelwch 6 digid.",
         "paragraph2": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
-        "paragraph3": "Bydd y cod yn dod i ben ar ôl 15 munud.",
-        "requestNewCodeLink": "Gofynnwch am god newydd",
-        "requestNewCodeParagraph": " os:",
-        "requestNewCodeReason1": "nad yw'r cod yn gweithio neu mae wedi dod i ben, neu ni wnaethoch dderbyn un",
-        "requestNewCodeReason2": "rydych eisiau defnyddio cyfeiriad e-bost gwahanol"
+        "paragraph3": "Bydd y cod yn dod i ben ar ôl 15 munud."
       },
       "code": {
         "label": "Rhowch y cod diogelwch 6 digid",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -231,19 +231,19 @@
       "title": "Check your email",
       "header": "Check your email",
       "text": "We have sent an email to: ",
+      "changeEmailLinkHref": "/change-email",
       "details": {
         "summaryText": "Problems with the code?",
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
         "sendCodeLinkHref": "/request-new-email-code",
         "text2": " or you can ",
-        "changeEmailLinkText": "use a different email address",
-        "changeEmailLinkHref": "/change-email"
+        "changeEmailLinkText": "use a different email address"
       },
       "info": {
         "paragraph1": "The email contains a 6 digit security code.",
         "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph3": "The code will expire after  15 minutes."
+        "paragraph3": "The code will expire after 15 minutes."
       },
       "code": {
         "label": "Enter the 6 digit security code",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -231,14 +231,19 @@
       "title": "Check your email",
       "header": "Check your email",
       "text": "We have sent an email to: ",
+      "details": {
+        "summaryText": "Problems with the code?",
+        "text1": "We can ",
+        "sendCodeLinkText": "send the code again",
+        "sendCodeLinkHref": "/request-new-email-code",
+        "text2": " or you can ",
+        "changeEmailLinkText": "use a different email address",
+        "changeEmailLinkHref": "/change-email"
+      },
       "info": {
         "paragraph1": "The email contains a 6 digit security code.",
         "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph3": "The code will expire after  15 minutes.",
-        "requestNewCodeLink": "Request a new code",
-        "requestNewCodeParagraph": " if:",
-        "requestNewCodeReason1": "the code isn’t working or has expired, or you didn’t receive one",
-        "requestNewCodeReason2": "you want to use a different email address"
+        "paragraph3": "The code will expire after  15 minutes."
       },
       "code": {
         "label": "Enter the 6 digit security code",

--- a/src/utils/state-machine.ts
+++ b/src/utils/state-machine.ts
@@ -1,4 +1,4 @@
-import { createMachine, EventType, StateValue } from "xstate";
+import {createMachine, EventType, StateValue} from "xstate";
 
 enum UserJourney {
   ChangeEmail = "changeEmail",
@@ -32,6 +32,7 @@ const amStateMachine = createMachine<AccountManagementEvent>({
       on: {
         VALUE_UPDATED: "CONFIRMATION",
         RESEND_CODE: "CHANGE_VALUE",
+        VERIFY_CODE_SENT: "CHANGE_VALUE"
       },
     },
     CONFIRMATION: { type: "final" },


### PR DESCRIPTION
## What?

* Updates the "Check your email" page to reflect content and design shown in the [Figma wireframe](https://www.figma.com/file/aVqNC4pKaebZchIU691f31/DI-Authentication?node-id=4194%3A17683) for Account Management. 
* Improves code formatting in `index.njk`
* Updates state machine to permit progression from `VERIFY_CODE` to `CHANGE_VALUE`

## Why?

This change is part of the AUT-599 ticket. 

## Related PRs

Similar changes have been made in the `di-authentication-frontend` [#729](https://github.com/alphagov/di-authentication-frontend/pull/729), [#722](https://github.com/alphagov/di-authentication-frontend/pull/722), [#717](https://github.com/alphagov/di-authentication-frontend/pull/717), [#715](https://github.com/alphagov/di-authentication-frontend/pull/715)
