### PR TITLE
AUT-669: Remove pattern attribute from numeric inputs

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -34,7 +34,6 @@
     name: "code",
     value: code,
     inputmode: "numeric",
-    pattern: "[0-9]*",
     spellcheck: false,
     errorMessage: {
         text: errors['code'].text

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -30,7 +30,6 @@
     name: "code",
     value: code,
     inputmode: "numeric",
-    pattern: "[0-9]*",
     spellcheck: false,
     errorMessage: {
         text: errors['code'].text


### PR DESCRIPTION
## What?

Remove pattern attribute from numeric inputs

## Why?

This update reflects a recent change to GOV.UK Design System recommendations for using pattern attributes on number inputs. The Design System update is described at: https://github.com/alphagov/govuk-design-system/pull/2323

## Related PRs
Similar PR raised in `di-authentication-frontend` here: https://github.com/alphagov/di-authentication-frontend/pull/740
