### PR TITLE
AUT-607: Get new code href link bug fix 

### DIFF
--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -3,6 +3,6 @@ import { PATH_DATA } from "../../app.constants";
 
 export function securityCodeInvalidGet(req: Request, res: Response): void {
   res.render("security-code-error/index.njk", {
-    newCodeLink: PATH_DATA.RESEND_MFA_CODE,
+    newCodeLink: PATH_DATA.REQUEST_NEW_CODE_OTP.url,
   });
 }


### PR DESCRIPTION
## What?

Use `/request-new-opt-code` url for `newCodeLink` when OTP limit exceeded changing phone number

## Why?

User is unable to redirect to request a new OTP code when limit has exceeded

## Related PRs

[Limit SMS OTP attempts, frontend changes](https://github.com/alphagov/di-authentication-account-management/pull/577)
