### PR TITLE
FIX: Update delete account integration test to use baseUrl

### DIFF
--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -6,6 +6,7 @@ import * as cheerio from "cheerio";
 import decache from "decache";
 import { API_ENDPOINTS, PATH_DATA } from "../../../app.constants";
 import { UnsecuredJWT } from "jose";
+import { getBaseUrl } from "../../../config";
 
 describe("Integration:: delete account", () => {
   let sandbox: sinon.SinonSandbox;
@@ -114,6 +115,7 @@ describe("Integration:: delete account", () => {
       .reply(204);
 
     const opApi = process.env.API_BASE_URL;
+    const baseUrl = getBaseUrl();
 
     request(app)
       .post(PATH_DATA.DELETE_ACCOUNT.url)
@@ -125,7 +127,7 @@ describe("Integration:: delete account", () => {
       .expect(
         "Location",
         `${opApi}/logout?id_token_hint=${idToken}&post_logout_redirect_uri=${encodeURIComponent(
-          "http://localhost:6000" + PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url
+          `${baseUrl}${PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url}`
         )}`
       )
       .expect(302, done);


### PR DESCRIPTION
## What?

Update delete account integration test to use baseUrl

## Why?

Test had been failing locally due to a port mismatch (`6000` specified in the test while `process.env.PORT` is `6001`). All tests are now passing.