### PR TITLE
AUT-678: Clear Incorrect OTP

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -32,7 +32,6 @@
     classes:"govuk-input--width-5",
     id: "code",
     name: "code",
-    value: code,
     inputmode: "numeric",
     spellcheck: false,
     errorMessage: {

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -28,7 +28,6 @@
     classes:"govuk-input--width-5",
     id: "code",
     name: "code",
-    value: code,
     inputmode: "numeric",
     spellcheck: false,
     errorMessage: {


### PR DESCRIPTION
## What?

- We need to ensure that an incorrect OTP entered for change phone number and change email address clears.

## Why?

- So as to reduce the likelihood of a user trying to continue the journey using the same incorrect code

