### PR TITLE
BAU: Switch on Welsh in build

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -3,3 +3,5 @@ your_account_url    = ""
 common_state_bucket = "digital-identity-dev-tfstate"
 
 account_management_auto_scaling_enabled = true
+
+support_language_cy = "1"


### PR DESCRIPTION
## What?

Switch on Welsh in build.

## Why?

Make Welsh available so that accpetance tests can be built against it.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/744