### PR TITLE
BAU: Remove 'it.only' test and add linting to prevent usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   root: true,
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "mocha"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
@@ -25,5 +25,6 @@ module.exports = {
       "error",
       { blankLine: "any", prev: "*", next: "*" },
     ],
+    "mocha/no-exclusive-tests": "error",
   },
 };

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "dotenv": "^10.0.0",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "mocha": "^9.2.0",
@@ -129,6 +130,6 @@
     "uglify-js": "^3.14.3"
   },
   "resolutions": {
-      "minimist": "1.2.6"
+    "minimist": "1.2.6"
   }
 }

--- a/src/components/manage-your-account/tests/manage-your-account-controller.test.ts
+++ b/src/components/manage-your-account/tests/manage-your-account-controller.test.ts
@@ -25,12 +25,15 @@ describe("manage you account controller", () => {
       req.session.user = {
         email: "test@test.com",
         phoneNumber: "xxxxxxx7898",
+        isPhoneNumberVerified: true,
       };
       manageYourAccountGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("manage-your-account/index.njk", {
         email: "test@test.com",
         phoneNumber: "*******7898",
+        isPhoneNumberVerified: true,
+        manageEmailsLink: 'https://www.gov.uk/email/manage'
       });
     });
   });

--- a/src/components/signed-out/tests/signed-out-controller.test.ts
+++ b/src/components/signed-out/tests/signed-out-controller.test.ts
@@ -26,7 +26,7 @@ describe("signed out controller", () => {
   });
 
   describe("signedOutGet", () => {
-    it.only("should return signed out page", () => {
+    it("should return signed out page", () => {
       signedOutGet(req as Request, res as Response);
 
       expect(res.render).to.have.been.calledWith("signed-out/index.njk");

--- a/test/unit/utils/state-machine.test.ts
+++ b/test/unit/utils/state-machine.test.ts
@@ -29,7 +29,7 @@ describe("state-machine", () => {
     it("should move state from change value state to verify code state", () => {
       const nextState = getNextState("CHANGE_VALUE", "VERIFY_CODE_SENT");
       expect(nextState.value).to.equal("VERIFY_CODE");
-      expect(nextState.events).to.all.members(["VALUE_UPDATED", "RESEND_CODE"]);
+      expect(nextState.events).to.all.members(["VALUE_UPDATED", "RESEND_CODE", "VERIFY_CODE_SENT"]);
     });
 
     it("should move state from verify code state to value updated state", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,6 +1602,14 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
+eslint-plugin-mocha@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz#69325414f875be87fb2cb00b2ef33168d4eb7c8d"
+  integrity sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==
+  dependencies:
+    eslint-utils "^3.0.0"
+    rambda "^7.1.0"
+
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
@@ -3298,6 +3306,11 @@ quick-format-unescaped@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
   integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
+
+rambda@^7.1.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/rambda/-/rambda-7.2.1.tgz#c533f6e2def4edcd59f967df938ace5dd6da56af"
+  integrity sha512-Wswj8ZvzdI3VhaGPkZAxaCTwuMmGtgWt7Zxsgyo4P+iTmVnkojvyWaOep5q3ZjMIecW0wtQa66GWxaKkZ24RAA==
 
 random-bytes@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## What?

BAU: Remove 'it.only' test and add linting to prevent usage.
Fix failing tests.

## Why?

'it.only' stops other tests from running so it shouldn't be committed.
