### PR TITLE
AUT-639: Pass User-Language header to services sending notifications.

### DIFF
--- a/src/components/change-email/change-email-controller.ts
+++ b/src/components/change-email/change-email-controller.ts
@@ -8,6 +8,7 @@ import {
 } from "../../utils/validation";
 import { ChangeEmailServiceInterface } from "./types";
 import { changeEmailService } from "./change-email-service";
+import xss from "xss";
 
 const TEMPLATE_NAME = "change-email/index.njk";
 export function changeEmailGet(req: Request, res: Response): void {
@@ -42,7 +43,8 @@ export function changeEmailPost(
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip,
       res.locals.sessionId,
-      res.locals.persistentSessionId
+      res.locals.persistentSessionId,
+      xss(req.cookies.lng as string)
     );
 
     if (emailSent) {

--- a/src/components/change-email/change-email-service.ts
+++ b/src/components/change-email/change-email-service.ts
@@ -14,7 +14,8 @@ export function changeEmailService(
     email: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    userLanguage: string
   ): Promise<boolean> {
     const { status } = await axios.client.post<void>(
       API_ENDPOINTS.SEND_NOTIFICATION,
@@ -27,7 +28,8 @@ export function changeEmailService(
         [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
         sourceIp,
         persistentSessionId,
-        sessionId
+        sessionId,
+        userLanguage
       )
     );
 

--- a/src/components/change-email/tests/change-email-controller.test.ts
+++ b/src/components/change-email/tests/change-email-controller.test.ts
@@ -16,7 +16,7 @@ describe("change email controller", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
-    req = { body: {}, session: { user: {} } };
+    req = { body: {}, session: { user: {} }, cookies: { lng: "en" } };
     res = { render: sandbox.fake(), redirect: sandbox.fake(), locals: {} };
   });
 
@@ -44,6 +44,7 @@ describe("change email controller", () => {
         email: "test@dl.com",
         state: { changeEmail: getInitialState() },
       };
+      req.cookies.lng = "en";
 
       await changeEmailPost(fakeService)(req as Request, res as Response);
 

--- a/src/components/change-email/types.ts
+++ b/src/components/change-email/types.ts
@@ -5,6 +5,7 @@ export interface ChangeEmailServiceInterface {
     notificationType: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    userLanguage: string
   ) => Promise<boolean>;
 }

--- a/src/components/change-password/change-password-controller.ts
+++ b/src/components/change-password/change-password-controller.ts
@@ -9,6 +9,7 @@ import {
   formatValidationError,
 } from "../../utils/validation";
 import { BadRequestError } from "../../utils/errors";
+import xss from "xss";
 
 const changePasswordTemplate = "change-password/index.njk";
 
@@ -30,7 +31,8 @@ export function changePasswordPost(
       newPassword,
       req.ip,
       res.locals.sessionId,
-      res.locals.persistentSessionId
+      res.locals.persistentSessionId,
+      xss(req.cookies.lng as string)
     );
 
     if (response.success) {

--- a/src/components/change-password/change-password-service.ts
+++ b/src/components/change-password/change-password-service.ts
@@ -17,7 +17,8 @@ export function changePasswordService(
     newPassword: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    userLanguage: string
   ): Promise<ApiResponseResult> {
     const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.UPDATE_PASSWORD,
@@ -30,7 +31,8 @@ export function changePasswordService(
         [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
         sourceIp,
         persistentSessionId,
-        sessionId
+        sessionId,
+        userLanguage
       )
     );
     return createApiResponse(response, [HTTP_STATUS_CODES.NO_CONTENT]);

--- a/src/components/change-password/tests/change-password-controller.test.ts
+++ b/src/components/change-password/tests/change-password-controller.test.ts
@@ -19,7 +19,11 @@ describe("change password controller", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
-    req = { body: {}, session: { user: { state: { changePassword: {} } } } };
+    req = {
+      body: {},
+      session: { user: { state: { changePassword: {} } } },
+      cookies: { lng: "en" },
+    };
     res = { render: sandbox.fake(), redirect: sandbox.fake(), locals: {} };
   });
 

--- a/src/components/change-password/types.ts
+++ b/src/components/change-password/types.ts
@@ -7,6 +7,7 @@ export interface ChangePasswordServiceInterface {
     newPassword: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    userLanguage: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -11,6 +11,7 @@ import {
 } from "../../utils/validation";
 import { prependInternationalPrefix } from "../../utils/phone-number";
 import { BadRequestError } from "../../utils/errors";
+import xss from "xss";
 
 const TEMPLATE_NAME = "change-phone-number/index.njk";
 
@@ -47,7 +48,8 @@ export function changePhoneNumberPost(
       newPhoneNumber,
       req.ip,
       res.locals.sessionId,
-      res.locals.persistentSessionId
+      res.locals.persistentSessionId,
+      xss(req.cookies.lng as string)
     );
 
     if (response.success) {

--- a/src/components/change-phone-number/change-phone-number-service.ts
+++ b/src/components/change-phone-number/change-phone-number-service.ts
@@ -21,7 +21,8 @@ export function changePhoneNumberService(
     phoneNumber: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    userLanguage: string
   ): Promise<ApiResponseResult> {
     const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.SEND_NOTIFICATION,
@@ -35,7 +36,8 @@ export function changePhoneNumberService(
         [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
         sourceIp,
         persistentSessionId,
-        sessionId
+        sessionId,
+        userLanguage
       )
     );
     return createApiResponse(response, [HTTP_STATUS_CODES.NO_CONTENT]);

--- a/src/components/change-phone-number/tests/change-phone-number-controller.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-controller.test.ts
@@ -22,6 +22,7 @@ describe("change phone number controller", () => {
     req = {
       body: {},
       session: { user: { state: { changePhoneNumber: {} } } },
+      cookies: { lng: "en" },
       i18n: { language: "" },
       t: sandbox.fake(),
     };

--- a/src/components/change-phone-number/types.ts
+++ b/src/components/change-phone-number/types.ts
@@ -7,6 +7,7 @@ export interface ChangePhoneNumberServiceInterface {
     phoneNumber: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    userLanguage: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -10,6 +10,7 @@ import { CheckYourEmailServiceInterface } from "./types";
 import { getNextState } from "../../utils/state-machine";
 import { GovUkPublishingServiceInterface } from "../common/gov-uk-publishing/types";
 import { govUkPublishingService } from "../common/gov-uk-publishing/gov-uk-publishing-service";
+import xss from "xss";
 
 const TEMPLATE_NAME = "check-your-email/index.njk";
 
@@ -36,7 +37,8 @@ export function checkYourEmailPost(
       code,
       req.ip,
       res.locals.sessionId,
-      res.locals.persistentSessionId
+      res.locals.persistentSessionId,
+      xss(req.cookies.lng as string)
     );
 
     if (isEmailUpdated) {

--- a/src/components/check-your-email/check-your-email-service.ts
+++ b/src/components/check-your-email/check-your-email-service.ts
@@ -13,7 +13,8 @@ export function checkYourEmailService(
     code: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    userLanguage: string
   ): Promise<boolean> {
     const { status }: AxiosResponse = await axios.client.post(
       API_ENDPOINTS.UPDATE_EMAIL,
@@ -27,7 +28,8 @@ export function checkYourEmailService(
         [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
         sourceIp,
         persistentSessionId,
-        sessionId
+        sessionId,
+        userLanguage
       )
     );
 

--- a/src/components/check-your-email/tests/check-your-email-controller.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-controller.test.ts
@@ -23,6 +23,7 @@ describe("check your email controller", () => {
     req = {
       body: {},
       session: { user: { state: { changeEmail: {} } } },
+      cookies: { lng: "en" },
       i18n: { language: "en" },
     };
     res = {

--- a/src/components/check-your-email/types.ts
+++ b/src/components/check-your-email/types.ts
@@ -6,6 +6,7 @@ export interface CheckYourEmailServiceInterface {
     code: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    userLanguage: string
   ) => Promise<boolean>;
 }

--- a/src/components/check-your-phone/check-your-phone-service.ts
+++ b/src/components/check-your-phone/check-your-phone-service.ts
@@ -3,37 +3,39 @@ import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
 import { CheckYourPhoneServiceInterface } from "./types";
 
 export function checkYourPhoneService(
-    axios: Http = http
+  axios: Http = http
 ): CheckYourPhoneServiceInterface {
-    const updatePhoneNumber = async function (
-        accessToken: string,
-        email: string,
-        phoneNumber: string,
-        otp: string,
-        sourceIp: string,
-        sessionId: string,
-        persistentSessionId: string
-    ): Promise<boolean> {
-        const { status } = await axios.client.post<void>(
-            API_ENDPOINTS.UPDATE_PHONE_NUMBER,
-            {
-                email,
-                otp,
-                phoneNumber,
-            },
-            getRequestConfig(
-                accessToken,
-                [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
-                sourceIp,
-                persistentSessionId,
-                sessionId
-            )
-        );
+  const updatePhoneNumber = async function (
+    accessToken: string,
+    email: string,
+    phoneNumber: string,
+    otp: string,
+    sourceIp: string,
+    sessionId: string,
+    persistentSessionId: string,
+    userLanguage: string
+  ): Promise<boolean> {
+    const { status } = await axios.client.post<void>(
+      API_ENDPOINTS.UPDATE_PHONE_NUMBER,
+      {
+        email,
+        otp,
+        phoneNumber,
+      },
+      getRequestConfig(
+        accessToken,
+        [HTTP_STATUS_CODES.NO_CONTENT, HTTP_STATUS_CODES.BAD_REQUEST],
+        sourceIp,
+        persistentSessionId,
+        sessionId,
+        userLanguage
+      )
+    );
 
-        return status === HTTP_STATUS_CODES.NO_CONTENT;
-    };
+    return status === HTTP_STATUS_CODES.NO_CONTENT;
+  };
 
-    return {
-        updatePhoneNumber,
-    };
+  return {
+    updatePhoneNumber,
+  };
 }

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -21,6 +21,7 @@ describe("check your phone controller", () => {
     req = {
       body: {},
       session: { user: { state: { changePhoneNumber: {} } } },
+      cookies: { lng: "en" },
       i18n: { language: "en" },
     };
     res = {
@@ -56,7 +57,7 @@ describe("check your phone controller", () => {
 
       expect(fakeService.updatePhoneNumber).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(
-          PATH_DATA.PHONE_NUMBER_UPDATED_CONFIRMATION.url
+        PATH_DATA.PHONE_NUMBER_UPDATED_CONFIRMATION.url
       );
     });
 

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -20,32 +20,32 @@ describe("Integration:: check your phone", () => {
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
     sandbox = sinon.createSandbox();
     sandbox
-        .stub(sessionMiddleware, "requiresAuthMiddleware")
-        .callsFake(function (req: any, res: any, next: any): void {
-          req.session.user = {
-            email: "test@test.com",
-            phoneNumber: "07839490040",
-            isAuthenticated: true,
-            state: {
-              changePhoneNumber: {
-                value: "VERIFY_CODE",
-                events: ["VALUE_UPDATED", "CONFIRMATION"],
-              },
+      .stub(sessionMiddleware, "requiresAuthMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        req.session.user = {
+          email: "test@test.com",
+          phoneNumber: "07839490040",
+          isAuthenticated: true,
+          state: {
+            changePhoneNumber: {
+              value: "VERIFY_CODE",
+              events: ["VALUE_UPDATED", "CONFIRMATION"],
             },
-            tokens: {
-              accessToken: new UnsecuredJWT({})
-                  .setIssuedAt()
-                  .setSubject("12345")
-                  .setIssuer("urn:example:issuer")
-                  .setAudience("urn:example:audience")
-                  .setExpirationTime("2h")
-                  .encode(),
-              idToken: "Idtoken",
-              refreshToken: "token",
-            },
-          };
-          next();
-        });
+          },
+          tokens: {
+            accessToken: new UnsecuredJWT({})
+              .setIssuedAt()
+              .setSubject("12345")
+              .setIssuer("urn:example:issuer")
+              .setAudience("urn:example:audience")
+              .setExpirationTime("2h")
+              .encode(),
+            idToken: "Idtoken",
+            refreshToken: "token",
+          },
+        };
+        next();
+      });
 
     const oidc = require("../../../utils/oidc");
     sandbox.stub(oidc, "getOIDCClient").callsFake(() => {
@@ -64,12 +64,12 @@ describe("Integration:: check your phone", () => {
     baseApi = process.env.AM_API_BASE_URL;
 
     request(app)
-        .get(PATH_DATA.CHECK_YOUR_PHONE.url)
-        .end((err, res) => {
-          const $ = cheerio.load(res.text);
-          token = $("[name=_csrf]").val();
-          cookies = res.headers["set-cookie"];
-        });
+      .get(PATH_DATA.CHECK_YOUR_PHONE.url)
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
   });
 
   beforeEach(() => {
@@ -87,116 +87,116 @@ describe("Integration:: check your phone", () => {
 
   it("should return error when csrf not present", (done) => {
     request(app)
-        .post(PATH_DATA.CHECK_YOUR_PHONE.url)
-        .type("form")
-        .send({
-          code: "123456",
-        })
-        .expect(500, done);
+      .post(PATH_DATA.CHECK_YOUR_PHONE.url)
+      .type("form")
+      .send({
+        code: "123456",
+      })
+      .expect(500, done);
   });
 
   it("should return validation error when code not entered", (done) => {
     request(app)
-        .post(PATH_DATA.CHECK_YOUR_PHONE.url)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          code: "",
-        })
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("#code-error").text()).to.contains("Enter the security code");
-        })
-        .expect(400, done);
+      .post(PATH_DATA.CHECK_YOUR_PHONE.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains("Enter the security code");
+      })
+      .expect(400, done);
   });
 
   it("should return validation error when code is less than 6 characters", (done) => {
     request(app)
-        .post(PATH_DATA.CHECK_YOUR_PHONE.url)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          code: "2",
-        })
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("#code-error").text()).to.contains(
-              "Enter the security code using only 6 digits"
-          );
-        })
-        .expect(400, done);
+      .post(PATH_DATA.CHECK_YOUR_PHONE.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "2",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          "Enter the security code using only 6 digits"
+        );
+      })
+      .expect(400, done);
   });
 
   it("should return validation error when code is greater than 6 characters", (done) => {
     request(app)
-        .post(PATH_DATA.CHECK_YOUR_PHONE.url)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          code: "1234567",
-        })
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("#code-error").text()).to.contains(
-              "Enter the security code using only 6 digits"
-          );
-        })
-        .expect(400, done);
+      .post(PATH_DATA.CHECK_YOUR_PHONE.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "1234567",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          "Enter the security code using only 6 digits"
+        );
+      })
+      .expect(400, done);
   });
 
   it("should return validation error when code entered contains letters", (done) => {
     request(app)
-        .post(PATH_DATA.CHECK_YOUR_PHONE.url)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          code: "12ert-",
-        })
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("#code-error").text()).to.contains(
-              "Enter the security code using only 6 digits"
-          );
-        })
-        .expect(400, done);
+      .post(PATH_DATA.CHECK_YOUR_PHONE.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "12ert-",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          "Enter the security code using only 6 digits"
+        );
+      })
+      .expect(400, done);
   });
 
   it("should redirect to /create-password when valid code entered", (done) => {
     nock(baseApi).post(API_ENDPOINTS.UPDATE_PHONE_NUMBER).once().reply(204);
 
     request(app)
-        .post(PATH_DATA.CHECK_YOUR_PHONE.url)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          code: "123456",
-        })
-        .expect("Location", PATH_DATA.PHONE_NUMBER_UPDATED_CONFIRMATION.url)
-        .expect(302, done);
+      .post(PATH_DATA.CHECK_YOUR_PHONE.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+      })
+      .expect("Location", PATH_DATA.PHONE_NUMBER_UPDATED_CONFIRMATION.url)
+      .expect(302, done);
   });
 
   it("should return validation error when incorrect code entered", (done) => {
     nock(baseApi).post(API_ENDPOINTS.UPDATE_PHONE_NUMBER).once().reply(400, {});
 
     request(app)
-        .post(PATH_DATA.CHECK_YOUR_PHONE.url)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          code: "123455",
-        })
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("#code-error").text()).to.contains(
-              "The security code you entered is not correct, or may have expired, try entering it again or request a new security code."
-          );
-        })
-        .expect(400, done);
+      .post(PATH_DATA.CHECK_YOUR_PHONE.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123455",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          "The security code you entered is not correct, or may have expired, try entering it again or request a new security code."
+        );
+      })
+      .expect(400, done);
   });
 });

--- a/src/components/check-your-phone/types.ts
+++ b/src/components/check-your-phone/types.ts
@@ -1,11 +1,12 @@
 export interface CheckYourPhoneServiceInterface {
   updatePhoneNumber: (
-      accessToken: string,
-      email: string,
-      phoneNumber: string,
-      otp: string,
-      sourceIp: string,
-      sessionId: string,
-      persistentSessionId: string
+    accessToken: string,
+    email: string,
+    phoneNumber: string,
+    otp: string,
+    sourceIp: string,
+    sessionId: string,
+    persistentSessionId: string,
+    userLanguage: string
   ) => Promise<boolean>;
 }

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -10,7 +10,7 @@ import { getBaseUrl, getManageGovukEmailsUrl } from "../../config";
 
 export function deleteAccountGet(req: Request, res: Response): void {
   res.render("delete-account/index.njk", {
-    manageEmailsLink: getManageGovukEmailsUrl()
+    manageEmailsLink: getManageGovukEmailsUrl(),
   });
 }
 

--- a/src/components/manage-your-account/tests/manage-your-account-controller.test.ts
+++ b/src/components/manage-your-account/tests/manage-your-account-controller.test.ts
@@ -33,7 +33,7 @@ describe("manage you account controller", () => {
         email: "test@test.com",
         phoneNumber: "*******7898",
         isPhoneNumberVerified: true,
-        manageEmailsLink: 'https://www.gov.uk/email/manage'
+        manageEmailsLink: "https://www.gov.uk/email/manage",
       });
     });
   });

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -33,7 +33,8 @@ export function getRequestConfig(
   validationStatues?: number[],
   sourceIp?: string,
   persistentSessionId?: string,
-  sessionId?: string
+  sessionId?: string,
+  userLanguage?: string
 ): AxiosRequestConfig {
   const config: AxiosRequestConfig = {
     headers: {
@@ -58,6 +59,10 @@ export function getRequestConfig(
 
   if (sessionId) {
     config.headers["Session-Id"] = sessionId;
+  }
+
+  if (userLanguage) {
+    config.headers["User-Language"] = userLanguage;
   }
 
   return config;


### PR DESCRIPTION
## What?

Pass user language as header to services sending notifications so that the Notify messages can be in both English and Welsh
Makes use of existing dormant changes to the account managemnt api.

Some unrelated tests have been formatted due to running 'pretty' on the codebase.

## Why?

Enable the Account Management backend to choose Notify template by language.


## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2324
https://github.com/alphagov/di-authentication-frontend/pull/749
https://github.com/alphagov/di-authentication-frontend/pull/750
