### PR TITLE
AUT-690 Localisation for "continue" and "back" 

### DIFF
--- a/src/components/change-email/index.njk
+++ b/src/components/change-email/index.njk
@@ -28,7 +28,7 @@
 }}
 
 {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -33,7 +33,7 @@
 }) }}
 
 {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -57,7 +57,7 @@
 }) }}
 
 {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -37,7 +37,7 @@
 }}
 
         {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}


### PR DESCRIPTION
## What?

Replaces hard-coded "Continue" with references to the translation values.

## Why?

So that buttons reflect the language choices of users.