### PR TITLE
AUT-714: Update "show password" component to support translations

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -64,7 +64,7 @@
   z-index: 0;
   display: table-cell; // IE fallback
   padding: govuk-spacing(1) govuk-spacing(3);
-  min-width: 5em; // stops the button width jumping when the text changes
+  min-width: 5.5em; // stops the button width jumping when the text changes
   color: $govuk-link-colour;
   text-decoration: underline;
   background: govuk-colour("white");

--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -24,8 +24,30 @@
 
      <p class="govuk-body">{{'pages.changePassword.password.paragraph2' | translate}}</p>
 
-    {{ govukInputWithShowPassword('pages.changePassword.password.label'  | translate, "password", errors) }}
-    {{ govukInputWithShowPassword('pages.changePassword.confirmPassword.label' | translate, "confirm-password", errors) }}
+    {{ govukInputWithShowPassword(
+        'pages.changePassword.password.label'  | translate,
+        "password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }) }}
+    {{ govukInputWithShowPassword(
+        'pages.changePassword.confirmPassword.label' | translate,
+        "confirm-password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }) }}
 
 {{ govukDetails({
   summaryText: 'pages.changePassword.securePasswordDetails.summary' | translate,

--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% macro govukInputWithShowPassword(label, id, errors) %}
-    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">
+{% macro govukInputWithShowPassword(label, id, errors, showSettings) %}
+    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ showSettings.show }}" data-hide-text="{{ showSettings.hide }}" data-show-full-text="{{ showSettings.showFullText }}" data-hide-full-text="{{ showSettings.hideFullText }}" data-announce-show="{{ showSettings.announceShown }}" data-announce-hide="{{ showSettings.announceHidden }}">
         {{ govukInput({
             label: {
                 text: label

--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -1,13 +1,10 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% macro govukInputWithShowPassword(label, id, errors, hint) %}
+{% macro govukInputWithShowPassword(label, id, errors) %}
     <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">
         {{ govukInput({
             label: {
                 text: label
-            },
-            hint: {
-                text: hint
             },
             classes: "govuk-!-width-two-thirds govuk-password-input",
             id: id,

--- a/src/components/enter-password/_change-email.njk
+++ b/src/components/enter-password/_change-email.njk
@@ -7,7 +7,18 @@
 
     <p class="govuk-body">{{'pages.enterPassword.changeEmail.paragraph' | translate}}</p>
 
-    {{ govukInputWithShowPassword('pages.enterPassword.password.label' | translate, "password", errors) }}
+    {{ govukInputWithShowPassword(
+        'pages.enterPassword.password.label' | translate,
+        "password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }) }}
 
     {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/components/enter-password/_change-password.njk
+++ b/src/components/enter-password/_change-password.njk
@@ -7,7 +7,18 @@
 
     <p class="govuk-body">{{'pages.enterPassword.changePassword.paragraph' | translate}}</p>
 
-    {{ govukInputWithShowPassword('pages.enterPassword.password.label' | translate, "password", errors) }}
+    {{ govukInputWithShowPassword(
+        'pages.enterPassword.password.label' | translate,
+        "password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }) }}
 
     {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/components/enter-password/_change-phone-number.njk
+++ b/src/components/enter-password/_change-phone-number.njk
@@ -7,7 +7,18 @@
 
     <p class="govuk-body">{{'pages.enterPassword.changePhoneNumber.paragraph' | translate}}</p>
 
-    {{ govukInputWithShowPassword('pages.enterPassword.password.label' | translate, "password", errors) }}
+    {{ govukInputWithShowPassword(
+        'pages.enterPassword.password.label' | translate,
+        "password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }) }}
 
     {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/components/enter-password/_delete-account.njk
+++ b/src/components/enter-password/_delete-account.njk
@@ -7,7 +7,18 @@
 
     <p class="govuk-body">{{'pages.enterPassword.deleteAccount.paragraph' | translate}}</p>
 
-    {{ govukInputWithShowPassword('pages.enterPassword.password.label' | translate, "password", errors) }}
+    {{ govukInputWithShowPassword(
+        'pages.enterPassword.password.label' | translate,
+        "password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }) }}
 
     {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -69,6 +69,14 @@
         "pageTitle": "Hysbysiad preifatrwydd",
         "linkText": "Hysbysiad preifatrwydd"
       }
+    },
+    "showPassword": {
+      "show": "Dangos",
+      "hide": "TBC",
+      "showFullText": "TBC",
+      "hideFullText": "TBC",
+      "announceShown": "TBC",
+      "announceHidden": "TBC"
     }
   },
   "error": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -72,11 +72,11 @@
     },
     "showPassword": {
       "show": "Dangos",
-      "hide": "TBC",
-      "showFullText": "TBC",
-      "hideFullText": "TBC",
-      "announceShown": "TBC",
-      "announceHidden": "TBC"
+      "hide": "Cuddio",
+      "showFullText": "Dangos cyfrinair",
+      "hideFullText": "Cuddio cyfrinair",
+      "announceShown": "Mae eich cyfrinair wedi'i ddangos",
+      "announceHidden": "Mae eich cyfrinair wedi'i guddio"
     }
   },
   "error": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -69,6 +69,14 @@
         "pageTitle": "Privacy notice",
         "linkText": "Privacy notice"
       }
+    },
+    "showPassword": {
+      "show": "Show",
+      "hide": "Hide",
+      "showFullText": "Show password",
+      "hideFullText": "Hide password",
+      "announceShown": "Your password is shown",
+      "announceHidden": "Your password is hidden"
     }
   },
   "error": {


### PR DESCRIPTION
## What?

This commit updates the two show password macros and all their implementations to:

1. Remove the unused 'hint' parameter that was causing an unnecessary element to be included in the HTML payload
2. Support translations via a new `showSettings` config object

Please include a summary of the change.

## Why?

So that users viewing the page in Welsh have the component translated correctly. 