### PR TITLE
AUT-691: Tweak i18next cookie config

### DIFF
--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -7,7 +7,6 @@ export function i18nextConfigurationOptions(
   return {
     debug: false,
     fallbackLng: LOCALE.EN,
-    lng: LOCALE.EN,
     preload: [LOCALE.EN],
     supportedLngs: supportLanguageCY() ? [LOCALE.EN, LOCALE.CY] : [LOCALE.EN],
     backend: {
@@ -22,6 +21,7 @@ export function i18nextConfigurationOptions(
       ignoreCase: true,
       cookieSecure: true,
       cookieDomain: getServiceDomain(),
+      cookieSameSite: "",
     },
   };
 }


### PR DESCRIPTION
## What?

i18next cookie tweaks.

- Remove use of SameSite for the lng cookie.
- Remove lng parameter from configuration.

## Why?

Fixes an issue where the lng cookie set by the backend in /authorize was not being respected by the frontend, so service language preferences were not being followed.

- lng parameter overrides language detection and is not required when detection is in use. The fallback language (en) still applies if no language is set.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/765
https://github.com/alphagov/di-authentication-frontend/pull/763
https://github.com/alphagov/di-authentication-account-management/pull/602
