### PR TITLE
AUT-389-frontend-changes: Add new /account-locked page when user trie…

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -72,6 +72,7 @@ export const PATH_DATA: {
   START: { url: "/" },
   HEALTHCHECK: { url: "/healthcheck" },
   GLOBAL_LOGOUT: { url: "/global-logout" },
+  ACCOUNT_LOCKED: { url: "/account-locked" },
 };
 
 export const API_ENDPOINTS = {
@@ -124,9 +125,38 @@ export const ERROR_CODES = {
   NEW_PASSWORD_SAME_AS_EXISTING: 1024,
   PASSWORD_IS_COMMON: 1040,
   NEW_PHONE_NUMBER_SAME_AS_EXISTING: 1044,
+  INVALID_PASSWORD_MAX_ATTEMPTS_REACHED: 1028,
 };
 
 export const ENVIRONMENT_NAME = {
   PROD: "production",
   DEV: "development",
 };
+
+export const ERROR_CODE_MAPPING: { [p: string]: string } = {
+  [ERROR_CODES.INVALID_PASSWORD_MAX_ATTEMPTS_REACHED]: pathWithQueryParam(
+    PATH_DATA["ACCOUNT_LOCKED"].url
+  ),
+};
+
+function pathWithQueryParam(path: string, queryParam?: string, value?: string) {
+  if (queryParam && value) {
+    const queryParams = new URLSearchParams({
+      [queryParam]: value,
+    }).toString();
+
+    return path + "?" + queryParams;
+  }
+
+  return path;
+}
+
+export function getErrorPathByCode(errorCode: number): string | undefined {
+  const nextPath = ERROR_CODE_MAPPING[errorCode];
+
+  if (!nextPath) {
+    return undefined;
+  }
+
+  return nextPath;
+}

--- a/src/components/enter-password/enter-password-routes.ts
+++ b/src/components/enter-password/enter-password-routes.ts
@@ -3,6 +3,7 @@ import { PATH_DATA } from "../../app.constants";
 import {
   enterPasswordPost,
   enterPasswordGet,
+  enterPasswordAccountLockedGet
 } from "./enter-password-controller";
 import { asyncHandler } from "../../utils/async";
 import { validateEnterPasswordRequest } from "./enter-password-validation";
@@ -15,6 +16,12 @@ router.get(
   PATH_DATA.ENTER_PASSWORD.url,
   requiresAuthMiddleware,
   enterPasswordGet
+);
+
+router.get(
+  PATH_DATA.ACCOUNT_LOCKED.url,
+  requiresAuthMiddleware,
+  enterPasswordAccountLockedGet
 );
 
 router.post(

--- a/src/components/enter-password/enter-password-service.ts
+++ b/src/components/enter-password/enter-password-service.ts
@@ -1,6 +1,7 @@
-import { getRequestConfig, http, Http } from "../../utils/http";
+import { getRequestConfig, http, Http, createApiResponse } from "../../utils/http";
 import { EnterPasswordServiceInterface } from "./types";
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
+import { ApiResponse, ApiResponseResult } from "../../utils/types";
 
 export function enterPasswordService(
   axios: Http = http
@@ -12,8 +13,8 @@ export function enterPasswordService(
     sourceIp: string,
     sessionId: string,
     persistentSessionId: string
-  ): Promise<boolean> {
-    const { status } = await axios.client.post<void>(
+    ): Promise<ApiResponseResult> {
+    const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.AUTHENTICATE,
       {
         email: emailAddress,
@@ -31,7 +32,7 @@ export function enterPasswordService(
         sessionId
       )
     );
-    return status === HTTP_STATUS_CODES.NO_CONTENT;
+    return createApiResponse(response, [HTTP_STATUS_CODES.NO_CONTENT]);
   };
   return {
     authenticated,

--- a/src/components/enter-password/index-account-locked.njk.njk
+++ b/src/components/enter-password/index-account-locked.njk.njk
@@ -1,0 +1,30 @@
+@@ -0,0 +1,26 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% set pageTitleName = 'pages.accountLocked.title' | translate %}
+
+{% block content %}
+
+{% include "common/errors/errorSummary.njk" %}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.accountLocked.header' | translate}}</h1>
+
+<p class="govuk-body">{{'pages.accountLocked.paragraph' | translate}}</p>
+
+<p class="govuk-body">
+    {{'pages.accountLocked.info.paragraph1Start' | translate}}
+    <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.accountLocked.info.firstLink' | translate}}</a>
+    {{'pages.accountLocked.info.paragraph1End' | translate}}
+</p>
+
+<p class="govuk-body">
+    {{'pages.accountLocked.info.paragraph2Start' | translate}}
+    <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.accountLocked.info.secondLink' | translate}}</a>
+    {{'pages.accountLocked.info.paragraph2End' | translate}}
+</p>
+
+{% endblock %}

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -68,7 +68,9 @@ describe("enter password controller", () => {
   describe("enterPasswordPost", () => {
     it("should redirect to change-email when the password is correct", async () => {
       const fakeService: EnterPasswordServiceInterface = {
-        authenticated: sandbox.fake.returns(true),
+        authenticated: sandbox.fake.returns({
+          success: true,
+        }),
       };
 
       req.session.user = {

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -1,3 +1,5 @@
+import { ApiResponseResult } from "../../utils/types";
+
 export interface EnterPasswordServiceInterface {
   authenticated: (
     token: string,
@@ -6,5 +8,5 @@ export interface EnterPasswordServiceInterface {
     sourceIp: string,
     sessionId: string,
     persistentSessionId: string
-  ) => Promise<boolean>;
+  ) => Promise<ApiResponseResult>;
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -338,6 +338,19 @@
       "paragraph2": "Neu ",
       "govukLinkText": "ewch i hafan GOV.UK",
       "govukLinkHref": "https://www.gov.uk/"
+    },
+    "accountLocked": {
+      "title": "Mae eich cyfrif wedi'i gloi",
+      "header": "Mae eich cyfrif wedi'i gloi",
+      "paragraph": "Mae hyn oherwydd eich bod wedi rhoi'r cyfrinair anghywir i mewn fwy na 5 gwaith y tro diwethaf i chi geisio mewngofnodi. Mae hyn er mwyn cadw eich cyfrif yn ddiogel.",
+      "info": {
+        "paragraph1Start": "Gallwch ",
+        "firstLink": "geisio mewngofnodi eto ",
+        "paragraph1End": "ar ôl i 15 munud fynd heibio.",
+        "paragraph2Start": "Gallwch hefyd ",
+        "secondLink": "ailosod eich cyfrinair",
+        "paragraph2End": "."
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -338,6 +338,19 @@
       "paragraph2": "Or ",
       "govukLinkText": "go to the GOV.UK homepage",
       "govukLinkHref": "https://www.gov.uk/"
+    },
+    "accountLocked": {
+      "title": "Your account is locked",
+      "header": "Your account is locked",
+      "paragraph": "This is because you entered the wrong password more than 5 times the last time you tried to sign in. This is to keep your account secure.",
+      "info": {
+        "paragraph1Start": "You can ",
+        "firstLink": "try to sign in again ",
+        "paragraph1End": "after 15 minutes have passed.",
+        "paragraph2Start": "You can also ",
+        "secondLink": "reset your password",
+        "paragraph2End": "."
+      }
     }
   }
 }


### PR DESCRIPTION
## What?

- Add new `/account-locked` page 

## Why?

- Currently users are able to retry sign in even when their account is locked
- Users should be redirected to a /account-locked page instead of login page when they try to sign in again

## Related PRs

[Backend Changes](https://github.com/alphagov/di-authentication-api/pull/2363)
