### PR TITLE
BAU: Route correct logs to correct subscription

### DIFF
--- a/ci/terraform/cloudwatch.tf
+++ b/ci/terraform/cloudwatch.tf
@@ -61,7 +61,7 @@ resource "aws_cloudwatch_log_group" "ecs_account_management_task_log" {
 resource "aws_cloudwatch_log_subscription_filter" "ecs_account_management_task_log_subscription" {
   count           = length(var.logging_endpoint_arns)
   name            = "${aws_cloudwatch_log_group.ecs_account_management_task_log.name}-splunk-subscription-${count.index}"
-  log_group_name  = aws_cloudwatch_log_group.alb_waf_log.name
+  log_group_name  = aws_cloudwatch_log_group.ecs_account_management_task_log.name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
 


### PR DESCRIPTION
We were routing two sets of subscriptions to the WAF log group
