### PR TITLE
ACI-78: Create new Get Security Code page

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -72,6 +72,7 @@ export const PATH_DATA: {
   START: { url: "/" },
   HEALTHCHECK: { url: "/healthcheck" },
   GLOBAL_LOGOUT: { url: "/global-logout" },
+  RESEND_EMAIL_CODE: { url: "/resend-email-code" },
 };
 
 export const API_ENDPOINTS = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -56,6 +56,7 @@ import { healthcheckRouter } from "./components/healthcheck/healthcheck-routes";
 import { globalLogoutRouter } from "./components/global-logout/global-logout-routes";
 import { subjectSessionIndex } from "./utils/subject-session-index";
 import { subjectSessionIndexMiddleware } from "./middleware/subject-session-index-middleware";
+import { resendEmailCodeRouter } from "./components/resend-email-code/resend-email-code-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -148,6 +149,7 @@ async function createApp(): Promise<express.Application> {
   app.use(checkYourPhoneRouter);
   app.use(sessionExpiredRouter);
   app.use(signedOutRouter);
+  app.use(resendEmailCodeRouter);
 
   app.use(logErrorMiddleware);
   app.use(serverErrorHandler);

--- a/src/components/resend-email-code/index.njk
+++ b/src/components/resend-email-code/index.njk
@@ -1,0 +1,30 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageTitleName = 'pages.resendMfaCode.title' | translate %}
+{% set showBack = true %}
+{% set hrefBack = 'enter-code' %}
+
+
+{% set emailMessage = 'pages.resendMfaCode.email.recipientMessage' | translate %}
+
+{% block content %}
+    <form action="/resend-email-code" method="post" novalidate="novalidate">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate}}</h1>
+
+        {{ govukInsetText({
+            html: emailMessage + '<span class="govuk-body govuk-!-font-weight-bold">' + emailAddress + '</span>'
+        }) }}
+
+        <p class="govuk-body">{{'pages.resendMfaCode.email.paragraph' | translate}}</p>
+        {{ govukButton({
+        "text": 'pages.resendMfaCode.continue' | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+    </form>
+{% endblock %}

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -1,0 +1,64 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "../../types";
+import xss from "xss";
+import { getNextState } from "../../utils/state-machine";
+import { NOTIFICATION_TYPE, PATH_DATA } from "../../app.constants";
+import { ChangeEmailServiceInterface } from "../change-email/types";
+import { changeEmailService } from "../change-email/change-email-service";
+import {
+  formatValidationError,
+  renderBadRequest,
+} from "../../utils/validation";
+
+const TEMPLATE_NAME = "resend-email-code/index.njk";
+
+export function resendEmailCodeGet(req: Request, res: Response): void {
+  res.render(TEMPLATE_NAME, {
+    emailAddress: req.session.user.email,
+  });
+}
+
+function badRequest(req: Request, res: Response, errorMessage: string) {
+  const error = formatValidationError(
+    "email",
+    req.t(`pages.changeEmail.email.validationError.${errorMessage}`)
+  );
+
+  return renderBadRequest(res, req, TEMPLATE_NAME, error);
+}
+
+export function resendEmailCodePost(
+  service: ChangeEmailServiceInterface = changeEmailService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { email, newEmailAddress } = req.session.user;
+    const { accessToken } = req.session.user.tokens;
+
+    if (email.toLowerCase() === newEmailAddress.toLowerCase()) {
+      return badRequest(req, res, "sameEmail");
+    }
+
+    const emailSent = await service.sendCodeVerificationNotification(
+      accessToken,
+      newEmailAddress,
+      NOTIFICATION_TYPE.VERIFY_EMAIL,
+      req.ip,
+      res.locals.sessionId,
+      res.locals.persistentSessionId,
+      xss(req.cookies.lng as string)
+    );
+
+    if (emailSent) {
+      req.session.user.newEmailAddress = newEmailAddress;
+
+      req.session.user.state.changeEmail = getNextState(
+        req.session.user.state.changeEmail.value,
+        "VERIFY_CODE_SENT"
+      );
+
+      return res.redirect(PATH_DATA.CHECK_YOUR_EMAIL.url);
+    }
+
+    return badRequest(req, res, "alreadyInUse");
+  };
+}

--- a/src/components/resend-email-code/resend-email-code-routes.ts
+++ b/src/components/resend-email-code/resend-email-code-routes.ts
@@ -1,0 +1,27 @@
+import * as express from "express";
+import { PATH_DATA } from "../../app.constants";
+
+import {
+  resendEmailCodeGet,
+  resendEmailCodePost,
+} from "./resend-email-code-controller";
+import { asyncHandler } from "../../utils/async";
+import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
+import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
+
+const router = express.Router();
+
+router.get(
+  PATH_DATA.RESEND_EMAIL_CODE.url,
+  requiresAuthMiddleware,
+  resendEmailCodeGet
+);
+
+router.post(
+  PATH_DATA.RESEND_EMAIL_CODE.url,
+  requiresAuthMiddleware,
+  refreshTokenMiddleware(),
+  asyncHandler(resendEmailCodePost())
+);
+
+export { router as resendEmailCodeRouter };

--- a/src/components/resend-email-code/tests/resend-email-code-controller.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-controller.test.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+
+import {
+  resendEmailCodeGet,
+  resendEmailCodePost,
+} from "../resend-email-code-controller";
+import { ChangeEmailServiceInterface } from "../../change-email/types";
+import { getInitialState } from "../../../utils/state-machine";
+
+describe("check your email controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    req = {
+      body: {},
+      session: { user: {} },
+      cookies: { lng: "en" },
+      i18n: { language: "en" },
+    };
+    res = {
+      render: sandbox.fake(),
+      redirect: sandbox.fake(),
+      status: sandbox.fake(),
+      locals: {},
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("resendEmailCodeGet", () => {
+    it("should render resend email code view", () => {
+      resendEmailCodeGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("resend-email-code/index.njk");
+    });
+  });
+
+  describe("resendEmailCodePost", () => {
+    it("should redirect to /check-your-email when get security code is executed", async () => {
+      const fakeService: ChangeEmailServiceInterface = {
+        sendCodeVerificationNotification: sandbox.fake.returns(true),
+      };
+
+      req.session.user = {
+        tokens: { accessToken: "token" },
+        email: "test@dl.com",
+        newEmailAddress: "test@test.com",
+        state: { changeEmail: getInitialState() },
+      };
+      req.cookies.lng = "en";
+
+      await resendEmailCodePost(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.sendCodeVerificationNotification).to.have.been
+        .calledOnce;
+      expect(res.redirect).to.have.calledWith("/check-your-email");
+    });
+  });
+});

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -1,0 +1,88 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import nock = require("nock");
+import decache from "decache";
+import { PATH_DATA } from "../../../app.constants";
+import { UnsecuredJWT } from "jose";
+
+describe("Integration:: request email code", () => {
+  let sandbox: sinon.SinonSandbox;
+  let app: any;
+  const TEST_SUBJECT_ID = "jkduasd";
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/requires-auth-middleware");
+    const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
+    sandbox = sinon.createSandbox();
+    sandbox
+      .stub(sessionMiddleware, "requiresAuthMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        req.session.user = {
+          email: "test@test.com",
+          phoneNumber: "07839490040",
+          subjectId: TEST_SUBJECT_ID,
+          isAuthenticated: true,
+          state: {
+            changeEmail: {
+              value: "CHANGE_VALUE",
+              events: ["VALUE_UPDATED", "VERIFY_CODE_SENT"],
+            },
+          },
+          tokens: {
+            accessToken: new UnsecuredJWT({})
+              .setIssuedAt()
+              .setSubject("12345")
+              .setIssuer("urn:example:issuer")
+              .setAudience("urn:example:audience")
+              .setExpirationTime("2h")
+              .encode(),
+            idToken: "Idtoken",
+            refreshToken: "token",
+          },
+        };
+        next();
+      });
+
+    const oidc = require("../../../utils/oidc");
+    sandbox.stub(oidc, "getOIDCClient").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
+    app = await require("../../../app").createApp();
+
+    request(app).get(PATH_DATA.RESEND_EMAIL_CODE.url);
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sandbox.restore();
+    app = undefined;
+  });
+
+  it("should return resend email code page", (done) => {
+    request(app).get(PATH_DATA.RESEND_EMAIL_CODE.url).expect(200, done);
+  });
+
+  it("should return error when csrf not present", (done) => {
+    request(app)
+      .post(PATH_DATA.RESEND_EMAIL_CODE.url)
+      .type("form")
+      .send({
+        email: "123456",
+      })
+      .expect(500, done);
+  });
+});

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -344,6 +344,20 @@
       "paragraph2": "Neu ",
       "govukLinkText": "ewch i hafan GOV.UK",
       "govukLinkHref": "https://www.gov.uk/"
+    },
+    "resendMfaCode": {
+      "title": "Cael cod diogelwch",
+      "header": "Cael cod diogelwch",
+      "continue": "Cael cod diogelwch",
+      "message": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd.",
+      "phoneNumber": {
+        "default": "Byddwn yn anfon cod at y rhif ffôn sy'n gysylltiedig â'ch cyfrif",
+        "isResendCodeRequest": "Byddwn yn anfon cod i: [mobile]."
+      },
+      "email": {
+        "recipientMessage": "Byddwn yn anfon cod i: ",
+        "paragraph": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam."
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -250,7 +250,7 @@
         "summaryText": "Problems with the code?",
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
-        "sendCodeLinkHref": "/request-new-email-code",
+        "sendCodeLinkHref": "/resend-email-code",
         "text2": " or you can ",
         "changeEmailLinkText": "use a different email address"
       },
@@ -344,6 +344,20 @@
       "paragraph2": "Or ",
       "govukLinkText": "go to the GOV.UK homepage",
       "govukLinkHref": "https://www.gov.uk/"
+    },
+    "resendMfaCode": {
+      "title": "Get security code",
+      "header": "Get security code",
+      "continue": "Get security code",
+      "message": "Text messages can sometimes take a few minutes to arrive.",
+      "phoneNumber": {
+        "default": "We will send a code to the phone number linked to your account",
+        "isResendCodeRequest": "We will send a code to: [mobile]."
+      },
+      "email": {
+        "recipientMessage": "We will send a code to: ",
+        "paragraph": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder."
+      }
     }
   }
 }

--- a/src/utils/state-machine.ts
+++ b/src/utils/state-machine.ts
@@ -1,4 +1,4 @@
-import {createMachine, EventType, StateValue} from "xstate";
+import { createMachine, EventType, StateValue } from "xstate";
 
 enum UserJourney {
   ChangeEmail = "changeEmail",
@@ -32,7 +32,7 @@ const amStateMachine = createMachine<AccountManagementEvent>({
       on: {
         VALUE_UPDATED: "CONFIRMATION",
         RESEND_CODE: "CHANGE_VALUE",
-        VERIFY_CODE_SENT: "CHANGE_VALUE"
+        VERIFY_CODE_SENT: "CHANGE_VALUE",
       },
     },
     CONFIRMATION: { type: "final" },

--- a/test/unit/utils/state-machine.test.ts
+++ b/test/unit/utils/state-machine.test.ts
@@ -29,7 +29,11 @@ describe("state-machine", () => {
     it("should move state from change value state to verify code state", () => {
       const nextState = getNextState("CHANGE_VALUE", "VERIFY_CODE_SENT");
       expect(nextState.value).to.equal("VERIFY_CODE");
-      expect(nextState.events).to.all.members(["VALUE_UPDATED", "RESEND_CODE", "VERIFY_CODE_SENT"]);
+      expect(nextState.events).to.all.members([
+        "VALUE_UPDATED",
+        "RESEND_CODE",
+        "VERIFY_CODE_SENT",
+      ]);
     });
 
     it("should move state from verify code state to value updated state", () => {


### PR DESCRIPTION
## What?

- Create a “Get security code” page within the Account Management app that reflects what is shown in Figma
- Users clicking “send the code again” on the “Check your email” page are presented with the “Get security code” page
- Users clicking “Get security code” (on the “Get security code” page) results in:
    - a security code being sent to the email address
    - the user being directed to the “Check your email” page

## Why?

To provide an equivalent experience when requesting a new security code email during registration and managing an account.
