### PR TITLE
DCP-88 - Enable Welsh locale in the integration Environment

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -4,6 +4,8 @@ common_state_bucket = "digital-identity-dev-tfstate"
 
 account_management_auto_scaling_enabled = true
 
+support_language_cy = "1"
+
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## What?

Enable Welsh Language in Integration

## Why?

Part of the current push to enable Welsh within digital Identity

## Related PRs

Once merged and tested to satisfaction please follow up with the prod PR:
https://github.com/alphagov/di-authentication-account-management/compare/DCP-88-WelshInProd?expand=1
