### PR TITLE
DCP-88: Enable Welsh language in production

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -5,6 +5,8 @@ common_state_bucket = "digital-identity-prod-tfstate"
 
 account_management_ecs_desired_count = 4
 
+support_language_cy = "1"
+
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## What?

Enable Welsh Language in Production

## Why?

Part of the current push to enable Welsh within digital Identity

## Related PRs

Please only merge after we've merged integration and are satisfied the change has appeared there correctly
https://github.com/alphagov/di-authentication-account-management/pull/640
