### PR TITLE
BAU: Add alpha and bravo teams to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alphagov/digital-identity-authentication @alphagov/gov-uk-accounts
+* @alphagov/digital-identity-authentication, @alphagov/gov-uk-accounts-developers, @alphagov/gov-uk-accounts-bravo


### PR DESCRIPTION
## What?

Codeowners were incorrect so I couldn't merge