### PR TITLE
AUT-824: Fix international phone number validation rule

### DIFF
--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -1,9 +1,17 @@
-import { isValidPhoneNumber } from "libphonenumber-js/mobile";
+import {
+  isValidPhoneNumber,
+  parsePhoneNumberWithError,
+} from "libphonenumber-js/mobile";
 
 export function containsUKMobileNumber(value: string): boolean {
-  return (
-    isValidPhoneNumber(value, "GB") && /^([+?44]{2}|[07]{2}).*$/.test(value)
-  );
+  try {
+    return (
+      isValidPhoneNumber(value, "GB") &&
+      parsePhoneNumberWithError(value, "GB").countryCallingCode === "44"
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function containsInternationalMobileNumber(value: string): boolean {

--- a/test/unit/utils/phone-number.test.ts
+++ b/test/unit/utils/phone-number.test.ts
@@ -65,6 +65,14 @@ describe("phone-number", () => {
       expect(containsUKMobileNumber("+330645453322")).to.equal(false);
     });
 
+    it("should return false when starting with 0033", () => {
+      expect(containsUKMobileNumber("0033 645453322")).to.equal(false);
+    });
+
+    it("should return true when Isle of Man phone number entered", () => {
+      expect(containsUKMobileNumber("+44 7624 311111")).to.equal(true);
+    });
+
     it("should return false when starting with +33 without 0", () => {
       expect(containsUKMobileNumber("+33645453322")).to.equal(false);
     });


### PR DESCRIPTION
## What?
- Regex had previously accepted any phone number where first two numbers were 0 or 7.
- This includes many common international phone number formats e.h. 0033 for France.
- We are now relying on functions from our supporting library instead of regex to determine if a phone number is a UK one
- Note that we use country code rather than specifying country as GB, so as not to exclude Isle of Man and similar.

## Why?

- Whilst support international phone numbers feature flag is toggled to off ("0"), we do not wish to allow users to register with international phone numbers.