### PR TITLE
BAU: Stop writing to old logging endpoint

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -7,6 +7,5 @@ account_management_auto_scaling_enabled = true
 support_language_cy = "1"
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -7,6 +7,5 @@ account_management_auto_scaling_enabled = true
 support_language_cy = "1"
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -8,6 +8,5 @@ account_management_ecs_desired_count = 4
 support_language_cy = "1"
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -19,6 +19,5 @@ account_management_task_definition_memory = 512
 account_management_auto_scaling_enabled   = true
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]


### PR DESCRIPTION
The old endpoint has been deprecated
