### PR TITLE
GUA-462: Implement changes to manage your account area

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -13,31 +13,6 @@ $govuk-new-link-styles: true;
   }
 }
 
-.accounts-summary-list {
-  margin-bottom: govuk-spacing(7);
-
-  .govuk-summary-list {
-    border-top: 1px solid $govuk-border-colour;
-
-    @include govuk-media-query($until: "tablet") {
-      padding-top: govuk-spacing(3);
-    }
-  }
-
-  &.accounts-summary-list--paginated {
-    margin-bottom: 0;
-
-    .govuk-summary-list__row:last-of-type {
-      border-bottom: 0;
-    }
-
-    .govuk-summary-list__row:last-of-type .govuk-summary-list__key,
-    .govuk-summary-list__row:last-of-type .govuk-summary-list__value {
-      border-bottom: 0;
-    }
-  }
-}
-
 .govuk-show-password__input-wrapper {
   display: table; // IE fallback
   display: flex;

--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -1,93 +1,78 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% set pageTitleName = 'pages.manageYourAccount.title' | translate %}
+{% set pageTitleName = 'pages.yourSettings.title' | translate %}
 
 {% set govukSummaryListArgs =
 {
-    classes:"accounts-summary-list",
     rows: [
+      {
+        key: {
+          text: 'pages.yourSettings.summaryList.email' | translate
+        },
+        value: {
+          text: email
+        },
+        actions: {
+          items: [
             {
-                key: {
-                    text: 'pages.manageYourAccount.summaryList.email' | translate
-                },
-                value: {
-                    text: email
-                },
-                actions: {
-                    items: [
-                        {
-                            href: "/enter-password?type=changeEmail",
-                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.email' | translate
-                        }
-                    ]
-                }
-            },
-            {
-                key: {
-                    text: 'pages.manageYourAccount.summaryList.password' | translate
-                },
-                value: {
-                    text: "••••••••••••••••"
-                },
-                actions: {
-                    items: [
-                        {
-                            href: "/enter-password?type=changePassword",
-                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.password' | translate
-                        }
-                    ]
-                }
+              href: "/enter-password?type=changeEmail",
+              text: 'pages.yourSettings.summaryList.changeAction' | translate,
+              visuallyHiddenText: 'pages.yourSettings.summaryList.email' | translate
             }
+          ]
+        }
+      },
+      {
+        key: {
+          text: 'pages.yourSettings.summaryList.password' | translate
+        },
+        value: {
+          text: "••••••••••••••••"
+        },
+        actions: {
+          items: [
+            {
+              href: "/enter-password?type=changePassword",
+              text: 'pages.yourSettings.summaryList.changeAction' | translate,
+              visuallyHiddenText: 'pages.yourSettings.summaryList.password' | translate
+            }
+          ]
+        }
+      }
 ]} %}
 
 {% if isPhoneNumberVerified %}
-    {% set govukSummaryListArgs = (govukSummaryListArgs.rows.push(            {
-                key: {
-                    text: 'pages.manageYourAccount.summaryList.phoneNumber' | translate
-                },
-                value: {
-                    text: phoneNumber
-                },
-                actions: {
-                    items: [
-                        {
-                            href: "/enter-password?type=changePhoneNumber",
-                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.phoneNumber' | translate
-                        }
-                    ]
-                }
-            }), govukSummaryListArgs) %}
+  {% set govukSummaryListArgs = (govukSummaryListArgs.rows.push({
+    key: {
+        text: 'pages.yourSettings.summaryList.phoneNumber' | translate
+    },
+    value: {
+        text: phoneNumber
+    },
+    actions: {
+      items: [
+        {
+          href: "/enter-password?type=changePhoneNumber",
+          text: 'pages.yourSettings.summaryList.changeAction' | translate,
+          visuallyHiddenText: 'pages.yourSettings.summaryList.phoneNumber' | translate
+        }
+      ]
+    }
+  }), govukSummaryListArgs) %}
 {% endif %}
 
 {% block content %}
-    <div class="govuk-grid-row" id="your-account">
-        <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
-            <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.manageYourAccount.header' | translate }}</h1>
-            <p class="govuk-body">{{ 'pages.manageYourAccount.signedInStatus' | translate }}
-                <strong>{{ email }}</strong>
-            </p>
-            <hr class="govuk-section-break govuk-section-break--m">
-            <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.accountDetails' | translate }}</h2>
+  <div class="govuk-grid-row" id="your-account">
+    <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
+      <h1 class="govuk-heading-xl">{{ 'pages.yourSettings.header' | translate }}</h1>
 
-            {{ govukSummaryList(govukSummaryListArgs) }}
+      <h2 class="govuk-heading-m">{{ 'pages.yourSettings.accountDetails' | translate }}</h2>
 
-            <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.manageEmailSubscriptions.heading' | translate }}</h2>
-            <p class="govuk-body">{{ 'pages.manageYourAccount.manageEmailSubscriptions.info' | translate }}</p>
-            <a href="{{ manageEmailsLink }}" class="govuk-link govuk-body">{{ 'pages.manageYourAccount.manageEmailSubscriptions.link' | translate }}</a>
-            <hr class="govuk-section-break govuk-section-break--m">
-            <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.deleteAccount.heading' | translate }}</h2>
-            <p class="govuk-body">{{ 'pages.manageYourAccount.deleteAccount.info' | translate }}</p>
-            <a href="/enter-password?type=deleteAccount" class="govuk-link govuk-body">{{ 'pages.manageYourAccount.deleteAccount.link' | translate }}</a>
-            <hr class="govuk-section-break govuk-section-break--m">
-            <div class="information-box">
-                <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.aboutAccounts.heading' | translate }}</h2>
-                <p class="govuk-body">{{ 'pages.manageYourAccount.aboutAccounts.paragraph1' | translate }}</p>
-                <p class="govuk-body">{{ 'pages.manageYourAccount.aboutAccounts.paragraph2' | translate }}</p>
-                <p class="govuk-body">{{ 'pages.manageYourAccount.aboutAccounts.paragraph3' | translate }}</p>
-            </div>
-        </div>
+      {{ govukSummaryList(govukSummaryListArgs) }}
+      <h2 class="govuk-heading-m">{{ 'pages.yourSettings.deleteAccount.heading' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.yourSettings.deleteAccount.info' | translate }}</p>
+      <a href="/enter-password?type=deleteAccount" class="govuk-link govuk-body">{{ 'pages.yourSettings.deleteAccount.link' | translate }}</a>
+      <hr class="govuk-section-break govuk-section-break--m">
     </div>
+  </div>
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -121,10 +121,9 @@
     }
   },
   "pages": {
-    "manageYourAccount": {
-      "title": "Eich cyfrif GOV.UK",
-      "header": "Eich cyfrif GOV.UK",
-      "signedInStatus": "Rydych wedi mewngofnodi fel",
+    "yourSettings": {
+      "title": "Settings",
+      "header": "Settings",
       "accountDetails": "Eich manylion mewngofnodi",
       "summaryList": {
         "email": "Cyfeiriad e-bost",
@@ -132,21 +131,10 @@
         "phoneNumber": "Rhif ffôn",
         "changeAction": "Newid"
       },
-      "manageEmailSubscriptions": {
-        "heading": "Tanysgrifiadau e-bost GOV.UK",
-        "link": "Rheoli eich tanysgrifiadau e-bost GOV.UK",
-        "info": "Gweld a rheoli’r e-byst rydych yn eu cael am ddiweddariadau i dudalennau ar GOV.UK."
-      },
       "deleteAccount": {
-        "heading": "Dileu eich cyfrif GOV.UK",
-        "link": "Dileu eich cyfrif GOV.UK",
-        "info": "Bydd hyn yn dileu eich cyfrif GOV.UK yn barhaol. Ni fyddwch bellach yn gallu mewngofnodi i’r gwasanaethau rydych wedi’u defnyddio gyda’ch cyfrif."
-      },
-      "aboutAccounts": {
-        "heading": "Am gyfrifon GOV.UK",
-        "paragraph1": "Mae cyfrifon GOV.UK yn newydd. Ar hyn o bryd gallwch ond defnyddio eich cyfrif GOV.UK gydag ychydig o wasanaethau.",
-        "paragraph2": "Ar hyn o bryd mae cyfrifon GOV.UK ar wahân i gyfrifon eraill y llywodraeth (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
-        "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich cyfrif GOV.UK i fewngofnodi i’r rhan fwyaf o wasanaethau ar GOV.UK."
+        "heading": "Delete your GOV.UK One Login",
+        "link": "Delete your GOV.UK One Login",
+        "info": "This will permanently delete your GOV.UK One Login. You’ll no longer be able to sign in to the services you’ve used with it."
       }
     },
     "enterPassword": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -122,8 +122,8 @@
   },
   "pages": {
     "yourSettings": {
-      "title": "Settings",
-      "header": "Settings",
+      "title": "Gosodiadau",
+      "header": "Gosodiadau",
       "accountDetails": "Eich manylion mewngofnodi",
       "summaryList": {
         "email": "Cyfeiriad e-bost",
@@ -134,7 +134,7 @@
       "deleteAccount": {
         "heading": "Dileu eich cyfrif GOV.UK",
         "link": "Dileu eich cyfrif GOV.UK",
-        "info": "This will permanently delete your GOV.UK account. You’ll no longer be able to sign in to the services you access with your GOV.UK account details."
+        "info": "Bydd hyn yn dileu eich cyfrif GOV.UK yn barhaol. Ni fyddwch bellach yn gallu mewngofnodi i'r gwasanaethau rydych wedi'u defnyddio gyda'ch manylion cyfrif GOV.UK."
       }
     },
     "enterPassword": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -132,9 +132,9 @@
         "changeAction": "Newid"
       },
       "deleteAccount": {
-        "heading": "Delete your GOV.UK One Login",
-        "link": "Delete your GOV.UK One Login",
-        "info": "This will permanently delete your GOV.UK One Login. You’ll no longer be able to sign in to the services you’ve used with it."
+        "heading": "Dileu eich cyfrif GOV.UK",
+        "link": "Dileu eich cyfrif GOV.UK",
+        "info": "This will permanently delete your GOV.UK account. You’ll no longer be able to sign in to the services you access with your GOV.UK account details."
       }
     },
     "enterPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -121,10 +121,9 @@
     }
   },
   "pages": {
-    "manageYourAccount": {
-      "title": "Your GOV.UK account",
-      "header": "Your GOV.UK account",
-      "signedInStatus": "You’re signed in as",
+    "yourSettings": {
+      "title": "Settings",
+      "header": "Settings",
       "accountDetails": "Your sign in details",
       "summaryList": {
         "email": "Email address",
@@ -132,21 +131,10 @@
         "phoneNumber": "Phone number",
         "changeAction": "Change"
       },
-      "manageEmailSubscriptions": {
-        "heading": "GOV.UK email subscriptions",
-        "link": "Manage your GOV.UK email subscriptions",
-        "info": "See and manage the emails you get about updates to pages on GOV.UK."
-      },
       "deleteAccount": {
-        "heading": "Delete your GOV.UK account",
-        "link": "Delete your GOV.UK account",
-        "info": "This will permanently delete your GOV.UK account. You’ll no longer be able to sign in to the services you’ve used with your account."
-      },
-      "aboutAccounts": {
-        "heading": "About GOV.UK accounts",
-        "paragraph1": "GOV.UK accounts are new. At the moment you can only use your GOV.UK account with a few services.",
-        "paragraph2": "GOV.UK accounts are currently separate from other government accounts (for example Government Gateway or Universal Credit).",
-        "paragraph3": "In the future, you’ll be able to use your GOV.UK account to sign in to most services on GOV.UK."
+        "heading": "Delete your GOV.UK One Login",
+        "link": "Delete your GOV.UK One Login",
+        "info": "This will permanently delete your GOV.UK One Login. You’ll no longer be able to sign in to the services you’ve used with it."
       }
     },
     "enterPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -132,9 +132,9 @@
         "changeAction": "Change"
       },
       "deleteAccount": {
-        "heading": "Delete your GOV.UK One Login",
-        "link": "Delete your GOV.UK One Login",
-        "info": "This will permanently delete your GOV.UK One Login. You’ll no longer be able to sign in to the services you’ve used with it."
+        "heading": "Delete your GOV.UK account",
+        "link": "Delete your GOV.UK account",
+        "info": "This will permanently delete your GOV.UK account. You’ll no longer be able to sign in to the services you access with your GOV.UK account details."
       }
     },
     "enterPassword": {


### PR DESCRIPTION
Implement updates to the account management area (renamed to "settings") to reflect the new One Login brand name as well as updates based on the [newest designs for the account](https://www.figma.com/file/Q6n44LmHFsCOGzZ44QTW4U/Account-home?node-id=2666%3A17539) which include a new services page.

### Before
![Screenshot 2022-11-03 at 09 50 22](https://user-images.githubusercontent.com/7116819/199692241-de1710db-c525-4219-9383-a2a98b9c45d1.png)



### After
<img width="1402" alt="Screenshot 2022-11-03 at 09 43 29" src="https://user-images.githubusercontent.com/7116819/199692303-02bafd45-bafd-468b-b62c-5332e244be52.png">



## Related PRs
https://github.com/alphagov/di-authentication-account-management/pull/662