### PR TITLE
AUT-848 - Fix global logout for account management

### DIFF
--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -32,8 +32,9 @@ async function getOIDCClient(config: OIDCConfig): Promise<Client> {
 
 async function getJWKS(config: OIDCConfig) {
   const issuer = await cachedIssuer(config.idp_url);
-
-  return createRemoteJWKSet(new URL(issuer.metadata.jwks_uri));
+  return createRemoteJWKSet(new URL(issuer.metadata.jwks_uri), {
+    headers: { "User-Agent": '"AccountManagement/1.0.0"' },
+  });
 }
 
 const cached = pMemoize(getOIDCClient, { maxAge: 43200000 });


### PR DESCRIPTION
## What?

- Fix global logout for account management by setting the user-agent header in the request to the JWKs endpoint

## Why?

- The global logout for account management was failing because of the following error 'Unable to validate logout_token. Error: Expected 200 OK from the JSON Web Key Set HTTP response'
- The reason for this was that the request was being blocked by the OIDC WAF for not having the user-header set. Set the user-header in the request to the jwks endpoint so that account management can retrieve the JWKs and validate the logout token
