### PR TITLE
AUT-848 - Set logout cookie when global logout is successful

### DIFF
--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -73,7 +73,7 @@ export async function globalLogoutPost(
           sessionId
         );
       });
-
+    res.cookie("lo", "true");
     res.send(HTTP_STATUS_CODES.OK);
     return;
   }

--- a/src/components/global-logout/tests/global-logout-controller.test.ts
+++ b/src/components/global-logout/tests/global-logout-controller.test.ts
@@ -23,7 +23,7 @@ import { GetKeyFunction } from "jose/dist/types/types";
 describe("global logout controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
-  let res: Partial<Response>;
+  let res: any;
   let issuerJWKS: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput>;
   let keySet: GenerateKeyPairResult;
 
@@ -97,6 +97,12 @@ describe("global logout controller", () => {
     res = {
       status: sandbox.stub().returnsThis(),
       send: sandbox.fake(),
+      mockCookies: {
+        lo: "false",
+      },
+      cookie: function (name: string, value: string) {
+        this.mockCookies[name] = value;
+      },
     };
   });
 
@@ -112,6 +118,7 @@ describe("global logout controller", () => {
       await globalLogoutPost(req as Request, res as Response);
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token not a valid JWT", async () => {
@@ -125,6 +132,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token is present but not signed", async () => {
@@ -141,6 +149,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token signed by wrong key", async () => {
@@ -160,6 +169,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token contains invalid issuer", async () => {
@@ -177,6 +187,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token contains invalid audience", async () => {
@@ -193,6 +204,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token is too old", async () => {
@@ -209,6 +221,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token does not contain a subject", async () => {
@@ -224,6 +237,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token is blank", async () => {
@@ -232,6 +246,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token does not contain correct event", async () => {
@@ -249,6 +264,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token does not any events", async () => {
@@ -263,6 +279,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token contains invalid event", async () => {
@@ -280,6 +297,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 401 if logout_token contains valid but non-empty event", async () => {
@@ -298,6 +316,7 @@ describe("global logout controller", () => {
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.UNAUTHORIZED);
       expect(req.log.error).to.have.been.called;
+      expect(res.mockCookies.lo).to.equal("false");
     });
 
     it("should return 200 if logout_token is present and valid", async () => {
@@ -323,6 +342,7 @@ describe("global logout controller", () => {
           .getCall(1)
           .calledWith("123456", "session-2")
       ).eq(true);
+      expect(res.mockCookies.lo).to.equal("true");
     });
   });
 });


### PR DESCRIPTION
## What?

- Set logout cookie to true when global logout is successful

## Why?

- When there has been a successful global logout, we need to ensure that we set the `lo` cookie to true to imply the user is logged out.
- This cookie is checked in the `requires-auth-middleware.ts` to see if the user is still logged in or not. If this cookie value is set to true, then the user will be redirected to the signed out page.

