### PR TITLE
ACI:82: Update check your email code validity content from 15 minutes to 2 hours

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -257,7 +257,7 @@
       "info": {
         "paragraph1": "Mae’r e-bost yn cynnwys cod diogelwch 6 digid.",
         "paragraph2": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
-        "paragraph3": "Bydd y cod yn dod i ben ar ôl 15 munud."
+        "paragraph3": "Bydd y cod yn dod i ben ar ôl 2 awr."
       },
       "code": {
         "label": "Rhowch y cod diogelwch 6 digid",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -257,7 +257,7 @@
       "info": {
         "paragraph1": "The email contains a 6 digit security code.",
         "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph3": "The code will expire after 15 minutes."
+        "paragraph3": "The code will expire after 2 hours."
       },
       "code": {
         "label": "Enter the 6 digit security code",


### PR DESCRIPTION
## What?

- Update check your email code validity content from 15 minutes to 2 hours
- This is to reflect the backend changes in [pr](https://govukverify.atlassian.net/browse/ACI-76)

## Why?

- To be consistent with the change in code validity implemented in the backend
- To provide users with accurate content regarding the changes

## Related PRs
[Backend changes](https://govukverify.atlassian.net/browse/ACI-76)
