### PR TITLE
AUT-848 - Implement getSessions as an asynchronously const

### DIFF
--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -64,16 +64,15 @@ export async function globalLogoutPost(
   const token = await verifyLogoutToken(req);
 
   if (token && validateLogoutTokenClaims(token, req)) {
-    req.app.locals.subjectSessionIndexService
-      .getSessions(token.sub)
-      .forEach((sessionId: string) => {
-        req.app.locals.sessionStore.destroy(sessionId);
-        req.app.locals.subjectSessionIndexService.removeSession(
-          token.sub,
-          sessionId
-        );
-      });
-
+      await req.app.locals.subjectSessionIndexService.getSessions(token.sub).then(
+          (sessions: string[]) => sessions.forEach((sessionId: string) => {
+            req.app.locals.sessionStore.destroy(sessionId);
+            req.app.locals.subjectSessionIndexService.removeSession(
+                token.sub,
+                sessionId
+            );
+          })
+     )
     res.send(HTTP_STATUS_CODES.OK);
     return;
   }

--- a/src/components/global-logout/tests/global-logout-controller.test.ts
+++ b/src/components/global-logout/tests/global-logout-controller.test.ts
@@ -46,7 +46,7 @@ describe("global logout controller", () => {
           },
           subjectSessionIndexService: {
             removeSession: sandbox.fake(),
-            getSessions: sandbox.stub().returns(["session-1", "session-2"]),
+            getSessions: sandbox.stub().resolves(["session-1", "session-2"]),
           },
         },
       },

--- a/src/utils/subject-session-index.ts
+++ b/src/utils/subject-session-index.ts
@@ -11,18 +11,17 @@ export function subjectSessionIndex(
     redisClient.ZADD(subjectIdKey(subjectId), now, sessionId);
   };
 
-  const getSessions = (subjectId: string): string[] => {
-    const now = new Date().getTime();
-    purgeOld(subjectId, now);
-    let sessions: string[] = [];
-    redisClient.ZRANGE(subjectIdKey(subjectId), 0, now, (err, reply) => {
-      if (err) {
-        throw err;
-      }
-      return (sessions = reply);
+  const getSessions = (subjectId: string): Promise<string[]> => {
+    return new Promise((resolve, reject) => {
+      const now = new Date().getTime();
+      purgeOld(subjectId, now);
+      redisClient.ZRANGE(subjectIdKey(subjectId), 0, now, (err, reply) => {
+        if (err) {
+          reject(err);
+        }
+        return resolve(reply);
+      });
     });
-
-    return sessions;
   };
 
   const removeSession = (subjectId: string, sessionId: string): void => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -40,5 +40,5 @@ export interface Error {
 export interface SubjectSessionIndexService {
   addSession: (subjectId: string, sessionId: string) => void;
   removeSession: (subjectId: string, sessionId: string) => void;
-  getSessions: (subjectId: string) => string[];
+  getSessions: (subjectId: string) =>  Promise<string[]>;
 }


### PR DESCRIPTION
## What?

 - Implement getSessions as an asynchronously const

## Why?

- Previously the getSessions const was implemented as an synchronously call but the response from the redisClient when calling ZRANGE was returned in an asynchronous callback. This meant when the globol-logout-controller called the getSessions method, nothing was being returned immediately and therefore no sessions were received.
- By making the getSessions an async call and also the call to getSessions in the global-logout-controller, we ensure that we wait for any results to be returned from redis before moving on.
