### PR TITLE
AUT-879 - Delete all sessions when account is deleted

### DIFF
--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -51,7 +51,17 @@ export function deleteAccountPost(
         getBaseUrl() + PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url,
     });
 
-    req.session.destroy();
+    await req.app.locals.subjectSessionIndexService
+      .getSessions(req.session.user.subjectId)
+      .then((sessions: string[]) =>
+        sessions.forEach((sessionId: string) => {
+          req.app.locals.sessionStore.destroy(sessionId);
+          req.app.locals.subjectSessionIndexService.removeSession(
+            req.session.user.subjectId,
+            sessionId
+          );
+        })
+      );
 
     return res.redirect(logoutUrl);
   };


### PR DESCRIPTION
## What?

- When a user has deleted their account we should remove all sessions assoicated with that user.

## Why?

- Otherwise a user can still have an open session within account management and then when the user goes to perform an action the system will throw an error. 


