### PR TITLE
BAU: Tag images for the dev environment with the commit SHA

### DIFF
--- a/.github/workflows/cd-only.yml
+++ b/.github/workflows/cd-only.yml
@@ -60,10 +60,14 @@ jobs:
         id: publish-template
         env:
           ARTIFACT_BUCKET_NAME: ${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
         run: |
           echo "Running sam build on template file"
           sam build --template-file=./deploy/template.yaml
           mv .aws-sam/build/template.yaml cf-template.yaml
+          echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with new ECR image ref"
+          sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA|" cf-template.yaml
           zip template.zip cf-template.yaml
           aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"        
 

--- a/.github/workflows/cd-only.yml
+++ b/.github/workflows/cd-only.yml
@@ -52,10 +52,9 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
-          IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
 
       - name: Upload SAM Template to Bucket
         id: publish-template

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -63,11 +63,6 @@ Parameters:
     Description: The port on which the container is running
     Type: Number
     Default: 6001
-  DevFrontendContainer:
-    Description: The ECR container for overriding in development, if you want to target a specific version/tag
-    Type: String
-    # ECR Repo for dev is in the dev account - see dev envs account-mgmt-frontend-image cfn stack for details
-    Default: 985326104449.dkr.ecr.eu-west-2.amazonaws.com/account-mgmt-frontend-image-containerrepository-4wdxqsyli0gd:latest
   ECSClusterMaxCapacity:
     Description: The maximum capacity of the ECS Cluster Auto Scaling Target
     Type: Number
@@ -94,11 +89,6 @@ Parameters:
     Default: none
 
 Conditions:
-  IsNotDevelopment: !Or
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, integration ]
-    - !Equals [ !Ref Environment, production ]
   IsProduction: !Equals [ !Ref Environment, production ]
   UsePermissionsBoundary:
     Fn::Not:
@@ -399,10 +389,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Essential: true
-          Image: !If
-            - IsNotDevelopment
-            - "CONTAINER-IMAGE-PLACEHOLDER"
-            - !Ref DevFrontendContainer
+          Image: "CONTAINER-IMAGE-PLACEHOLDER"
           Name: !Sub "${AWS::StackName}-BlueTaskDefinition"
           PortMappings:
             - ContainerPort: !Ref ContainerPort


### PR DESCRIPTION
## Proposed changes
Previously this action would tag the Docker image as 'latest'. ECR handles this ok by saving the newly uploaded image as 'latest' and untagging the image that was previously 'latest'.

However when the CloudFormation template is applied, the running image in ECS isn't updated. I think this is for one of two reasons:

1. CloudFormation sees that ECS is already running an image tagged 'latest' and decides not to update it
2. ECS caches images and when the new task definition is started it uses the already cached 'latest' image, which isn't what we want.

Both of these can be prevented by tagging each image with a unique ID.

### What changed

This PR changes the action to tag the image with the commit SHA in the same way as the action which uploads an image for the secure pipeline.

This means we no longer need the condition or the hard coded image value for the dev environment.

### Why did it change

This action didn't deploy the new image to ECS. 

## Checklists

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Other considerations
- [ ] Demo to a BA, TA, and the team.
- [ ] Recorded demo shared on [#govuk-accounts-tech](https://gds.slack.com/archives/C011Y5SAY3U)
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
