### PR TITLE
ACI-11: Add new flag `OneLoginService` flag to client

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -75,15 +75,18 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     }
     CookieConsentShared = {
       N = "1"
-    },
+    }
     ConsentRequired = {
       N = "0"
-    },
+    }
     ClientType = {
       S = "web"
     }
     IdentityVerificationSupported = {
       N = "0"
+    }
+    OneLoginService = {
+      BOOL = true
     }
   })
 }


### PR DESCRIPTION
## Proposed changes

Add new flag `OneLoginService` flag to client

### What changed

- Amend the client registration to set the new `OneLoginService` flag to `true`

### Why did it change

We have a variation of the "account not found" page which needs to be displayed for when the RP is Account Management or other internal One Login services

### Issue tracking

- [ACI-11](https://govukverify.atlassian.net/browse/ACI-11)
