### PR TITLE
GUA-503: Show the user's new email when sending a new code

### DIFF
--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -14,7 +14,7 @@ const TEMPLATE_NAME = "resend-email-code/index.njk";
 
 export function resendEmailCodeGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
-    emailAddress: req.session.user.email,
+    emailAddress: req.session.user.newEmailAddress,
   });
 }
 

--- a/src/components/resend-email-code/tests/resend-email-code-controller.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-controller.test.ts
@@ -39,9 +39,14 @@ describe("check your email controller", () => {
 
   describe("resendEmailCodeGet", () => {
     it("should render resend email code view", () => {
+      req.session.user = {
+        newEmailAddress: "test@test.com",
+      };
       resendEmailCodeGet(req as Request, res as Response);
 
-      expect(res.render).to.have.calledWith("resend-email-code/index.njk");
+      expect(res.render).to.have.calledWith("resend-email-code/index.njk", {
+        emailAddress: "test@test.com",
+      });
     });
   });
 


### PR DESCRIPTION
## Proposed changes

Show the user's new email address when sending a new verification code.

Note - this doesn't change any behaviour about which email we send the code to. That's already working as intended - it already correctly goes to their new email address.

This change only switches the email displayed to the user to the right one.

### Why did it change

The only way a user can get a verification code sent to their email address by this app is while they're going through the journey to change their email address. The other credential and delete journeys require them to re-enter their password, but we never send a code to their email.

That means the only way a user can end up resending an email code is if they're trying to send a code to their new email address while they're in the process of switching. We should display their new email address on this page, but we're showing the old one. This is confusing, because the verification code gets sent to their new email address.

### Issue tracking
https://govukverify.atlassian.net/browse/GUA-503

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Other considerations
- [ ] Demo to a BA, TA, and the team.
- [ ] Recorded demo shared on [#govuk-accounts-tech](https://gds.slack.com/archives/C011Y5SAY3U)
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
