### PR TITLE
AUT-895: Enable redirects in staging

### DIFF
--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -4,3 +4,5 @@ common_state_bucket = "di-auth-staging-tfstate"
 
 account_management_auto_scaling_enabled = true
 support_language_cy                     = "1"
+
+account_management_redirect_url = "https://home.staging.account.gov.uk"


### PR DESCRIPTION
## Proposed changes

Enable redirects to new account management deployment in staging environment.

### What changed

- Add redirect URL to old deployment variables in staging.

### Why did it change

We are ready to start testing the switchover from the old to new deployments.

### Issue tracking

- [AUT-895](https://govukverify.atlassian.net/browse/AUT-895)
