### PR TITLE
BAU: Upgrade localstack 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ redirect.zip
 .pnp.*
 .yarn/
 .yarnrc.yml
+
+# Localstack
+volume/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.8'
 
 services:
   localstack:
-    image: localstack/localstack:0.12.15
+    container_name: localstack_main
+    image: localstack/localstack:1.2.0
     ports:
       - 4566:4566
     environment:
@@ -10,8 +11,10 @@ services:
       - HOSTNAME_EXTERNAL=localhost
       - DEFAULT_REGION=eu-west-2
       - DEBUG=1
+      - KMS_PROVIDER=local-kms
     volumes:
       - ./seed.yaml:/init/seed.yaml
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
 
   redis:
     image: redis:6.0.5-alpine


### PR DESCRIPTION
We're going to be adding a bunch more localstack services.
the version we were on was 16 months old and a major version behind.

Let's make sure if we're looking at docs we're looking at the latest ones.

## How to test
Pull this and with no other docker running do:
`docker compose up -d && docker compose logs -f`

visit localhost:6001, progress through sign in, and follow the redirects.
If you see the manage your account page, we're golden.

## Also test
When you don't have a LOCALSTACK_VOLUME_DIR env var, a gitignored volumes directory appears in the repo
When you do, it appears instead at your env var location.