### PR TITLE
AUT-895: Redirect Deployment Fixes

### DIFF
--- a/ci/tasks/deploy-account-management.yml
+++ b/ci/tasks/deploy-account-management.yml
@@ -66,7 +66,7 @@ run:
         -var "incoming_traffic_cidr_blocks=${INCOMING_TRAFFIC_CIDR_BLOCKS}" \
         -var "support_language_cy=${SUPPORT_LANGUAGE_CY}" \
         -var "shared_state_bucket=${STATE_BUCKET}" \
-        -var "redirect_lambda_zip=$(ls -1 ../../../../acct-mgmt-redirect-release/*.zip)" \
+        -var "redirect_lambda_zip=$(ls -1 ../../../acct-mgmt-redirect-release/*.zip)" \
         -var-file ${DEPLOY_ENVIRONMENT}.tfvars \
       
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -40,7 +40,7 @@ resource "aws_alb_listener" "account_management_alb_listener_https" {
   certificate_arn = aws_acm_certificate.account_management_alb_certificate.arn
 
   default_action {
-    target_group_arn = var.account_management_redirect_url == "" ? aws_alb_target_group.account_management_alb_target_group.id : aws_lb_target_group.redirect_lambda[0].arn
+    target_group_arn = aws_alb_target_group.account_management_alb_target_group.id
     type             = "forward"
   }
 
@@ -70,6 +70,25 @@ resource "aws_alb_listener_rule" "account_management_alb_listener_https_robots" 
     }
   }
 }
+
+resource "aws_alb_listener_rule" "account_management_alb_listener_redirect" {
+  count = var.account_management_redirect_url == "" ? 0 : 1
+
+  listener_arn = aws_alb_listener.account_management_alb_listener_https.arn
+  priority     = 20
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.redirect_lambda.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["*"]
+    }
+  }
+}
+
 
 resource "aws_alb_listener" "account_managment_alb_listener_http" {
   load_balancer_arn = aws_lb.account_management_alb.id


### PR DESCRIPTION
## Proposed changes

Fixes to the old deployment task and Terraform

### What changed

- Fix the path to the lambda ZIP file in the Concourse deployment task
- Always create the redirect lambda resources
- Add an optional rule to the load balancer rather than changing the default rule

### Why did it change

To remove the deployment errors being experienced into the staging environment, plus any future errors between the time the re-direct is switched on and the old infrastructure being retired.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [AUT-895](https://govukverify.atlassian.net/browse/AUT-895)

