### PR TITLE
AUT-895: Make target group name environment specific

### DIFF
--- a/ci/terraform/redirect-lambda.tf
+++ b/ci/terraform/redirect-lambda.tf
@@ -171,13 +171,13 @@ resource "aws_lambda_permission" "redirect_lambda" {
 }
 
 resource "aws_lb_target_group" "redirect_lambda" {
-  name        = "redirect-lambda"
+  name        = "${var.environment}-redirect-lambda"
   target_type = "lambda"
 
   tags = local.default_tags
 }
 
-resource "aws_lb_target_group_attachment" "test" {
+resource "aws_lb_target_group_attachment" "redirect_lambda" {
   target_group_arn = aws_lb_target_group.redirect_lambda.arn
   target_id        = aws_lambda_function.redirect_lambda.arn
   depends_on       = [aws_lambda_permission.redirect_lambda]


### PR DESCRIPTION
## Proposed changes

Minor fixes to Terraform

### What changed

- Target group didn't include environment name
- Correct name of target group attachment

### Why did it change

Deployment failed in build due to shared name

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [AUT-895](https://govukverify.atlassian.net/browse/AUT-895)

