### PR TITLE
AUT-895: Use correct CSLS in staging AM

### DIFF
--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -5,4 +5,8 @@ common_state_bucket = "di-auth-staging-tfstate"
 account_management_auto_scaling_enabled = true
 support_language_cy                     = "1"
 
+logging_endpoint_arns = [
+  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+]
+
 account_management_redirect_url = "https://home.staging.account.gov.uk"


### PR DESCRIPTION
## Proposed changes

Update the CSLS endpoint in staging.

### What changed

- Change the CSLS endpoint to the new `python` variant.

### Why did it change

This should have changed a while ago, but seems to have been missed and has been highlighted by trying to deploy a new log group to staging.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [AUT-895](https://govukverify.atlassian.net/browse/AUT-895)

