### PR TITLE
AUT-895: Switch on redirect in production

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -8,3 +8,5 @@ account_management_ecs_desired_count = 4
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+account_management_redirect_url = "https://home.account.gov.uk"


### PR DESCRIPTION


## Proposed changes

Switch production to redirect to the new infrastructure

### What changed

- Set the override URL in `production.tfvars`

### Why did it change

We are ready to switch over

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [AUT-895](https://govukverify.atlassian.net/browse/AUT-895)
