### PR TITLE
GUA-473: new header frontend tweaks

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -1,3 +1,5 @@
+$govuk-new-link-styles: true;
+
 @import "../../../node_modules/govuk-frontend/govuk/all";
 
 .information-box {
@@ -139,8 +141,11 @@
   @extend .govuk-link;
   display: inline-block;
   font-weight: bold;
-  text-decoration: none;
   padding: govuk-spacing(3) 0;
+  
+  &:not(:hover) {
+    text-decoration: none;
+  }
 
   &:visited {
     color: $govuk-link-colour;

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -35,7 +35,8 @@
 {% block header %}
   {% if supportNewAccountHeader %}
     {{ govukHeader({
-      homepageUrl: 'general.header.homepageHref' | translate
+      homepageUrl: 'general.header.homepageHref' | translate,
+      productName: 'general.header.productName' | translate
     }) }}
     {% if not hideSignOutLink %}
       {% include 'common/layout/navigation.njk' %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -49,6 +49,7 @@
     },    
     "header": {
       "homepageHref": "https://www.gov.uk/",
+      "productName": "Cyfrif",
       "accountLink": "Eich cyfrif GOV.UK",
       "accounNavHomeLink": "Your services",
       "accountNavSettingsLink": "Settings",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -49,6 +49,7 @@
     },
     "header": {
       "homepageHref": "https://www.gov.uk/",
+      "productName": "Account",
       "accountLink": "Your GOV.UK account",
       "accounNavHomeLink": "Your services",
       "accountNavSettingsLink": "Settings",


### PR DESCRIPTION
Implement changes after a UCD review of the new account navigation: 

- [add "Account" product name to header](https://github.com/alphagov/di-authentication-account-management/commit/7520b4a3a0dbc7e51471da6a6dc536a360fe1bcb)
- [update nav link hover state styles](https://github.com/alphagov/di-authentication-account-management/commit/8cd3b735ac8e0e06964b0e9d6f87d5f00e3098ce) 
- also adds the `$govuk-new-link-styles: true;` flag to the `application.scss` file. This enables the new DS link style with a thicker underline on hover, ensuring that the look of links is consistent across the account management app


https://user-images.githubusercontent.com/7116819/203791438-1db2e73f-d1f2-434b-be35-aea423ede0e1.mov



