### PR TITLE
GUA-541: Enable additional metrics for CloudFront

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1239,6 +1239,14 @@ Resources:
           QueryStringBehavior:
             all
 
+  CloudFrontMonitoringSubscription:
+    Type: AWS::CloudFront::MonitoringSubscription
+    Properties: 
+      DistributionId: !Ref CloudFrontDistribution
+      MonitoringSubscription:
+        RealtimeMetricsSubscriptionConfig:
+          RealtimeMetricsSubscriptionStatus: Enabled
+
   CloudFrontLogsBucket:
     Type: AWS::S3::Bucket
     Properties:


### PR DESCRIPTION
CloudFront exports some metrics to CloudWatch by default, but those don't include origin latency or the number of 4XX / 5XX responses.

Enable the real time metrics export to CloudWatch which include these metrics [[1]].

[1]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed