### PR TITLE
AUT-909: Add weight to apex domain DNS record

### DIFF
--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -3,6 +3,12 @@ resource "aws_route53_record" "account_management" {
   type    = "A"
   zone_id = local.zone_id
 
+  weighted_routing_policy {
+    weight = 255
+  }
+
+  set_identifier = local.default_tags.application
+
   alias {
     evaluate_target_health = false
     name                   = aws_lb.account_management_alb.dns_name


### PR DESCRIPTION
## Proposed changes

Add weighting to the Route53 record for the `account.gov.uk` domain.

### What changed

- Add the maximum weight to the DNS record for the apex domain `A` record.

### Why did it change

To provide zero downtime as we move the apex domain to a new home, we are creating a second version of this record in a different repo, with a different weight. Once this is in place, we shall reduce the weighting in this repo to `0` and then destroy it, as a first step to decommissioning the old infrastructure.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [AUT-909](https://govukverify.atlassian.net/browse/AUT-909)

