### PR TITLE
Revert "BAU: Switch off account management redirect"

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -9,4 +9,4 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-account_management_redirect_url = ""
+account_management_redirect_url = "https://home.account.gov.uk"


### PR DESCRIPTION
Reverts alphagov/di-authentication-account-management#728

We've fixed the issue that meant we needed to rollback to the old infrastructure, so we can safely restore the redirect and start serving production traffic again.