### PR TITLE
GUA-514: Send public subject ID to GOV.UK RP 

### DIFF
--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -26,8 +26,13 @@ export function checkYourEmailPost(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const code = req.body["code"];
-    const { email, newEmailAddress, subjectId, legacySubjectId } =
-      req.session.user;
+    const {
+      email,
+      newEmailAddress,
+      subjectId,
+      publicSubjectId,
+      legacySubjectId,
+    } = req.session.user;
     const { accessToken } = req.session.user.tokens;
 
     const isEmailUpdated = await service.updateEmail(
@@ -44,7 +49,7 @@ export function checkYourEmailPost(
     if (isEmailUpdated) {
       await publishingService
         .notifyEmailChanged({
-          subjectId: subjectId,
+          publicSubjectId: publicSubjectId,
           newEmail: newEmailAddress,
           legacySubjectId: legacySubjectId,
         })

--- a/src/components/common/gov-uk-publishing/gov-uk-publishing-service.ts
+++ b/src/components/common/gov-uk-publishing/gov-uk-publishing-service.ts
@@ -16,7 +16,7 @@ export function govUkPublishingService(
     request: GovUkNotificationRequest
   ): Promise<void> => {
     await axios.client.put<void>(
-      getRequestUrl(request.subjectId),
+      getRequestUrl(request.publicSubjectId),
       {
         email: request.newEmail,
         email_verified: true,
@@ -30,7 +30,7 @@ export function govUkPublishingService(
   const notifyAccountDeleted = async function (
     request: GovUkNotificationRequest
   ): Promise<void> {
-    let deleteUrl = getRequestUrl(request.subjectId);
+    let deleteUrl = getRequestUrl(request.publicSubjectId);
 
     if (request.legacySubjectId) {
       deleteUrl = deleteUrl + "?legacy_sub=" + request.legacySubjectId;

--- a/src/components/common/gov-uk-publishing/types.ts
+++ b/src/components/common/gov-uk-publishing/types.ts
@@ -1,5 +1,5 @@
 export interface GovUkNotificationRequest {
-  subjectId: string;
+  publicSubjectId: string;
   newEmail?: string;
   legacySubjectId: string;
 }

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -19,7 +19,8 @@ export function deleteAccountPost(
   publishingService: GovUkPublishingServiceInterface = govUkPublishingService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const { email, subjectId, legacySubjectId } = req.session.user;
+    const { email, subjectId, publicSubjectId, legacySubjectId } =
+      req.session.user;
     const { accessToken } = req.session.user.tokens;
 
     await service.deleteAccount(
@@ -31,7 +32,7 @@ export function deleteAccountPost(
     );
     await publishingService
       .notifyAccountDeleted({
-        subjectId,
+        publicSubjectId,
         legacySubjectId,
       })
       .catch((err) => {

--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -85,6 +85,7 @@ export function oidcAuthCallbackGet(
       isPhoneNumberVerified: userInfoResponse.phone_number_verified,
       subjectId: userInfoResponse.sub,
       legacySubjectId: userInfoResponse.legacy_subject_id,
+      publicSubjectId: userInfoResponse.public_subject_id,
       tokens: {
         idToken: tokenResponse.id_token,
         accessToken: tokenResponse.access_token,


### PR DESCRIPTION
Update the calls to GOV.UK's Account API to use the public subject ID. This is a new field returned in the userinfo response for this application. The public subject ID is the user ID the app currently gets as the subjectID, and it's also the user ID the GOV.UK relying party gets.

We want to change the subject ID for this app to the DI internal sector pairwise ID, but we also need the public subject ID so we can send notifications to GOV.UK when someone updates or deletes their account.

This PR stores the public subject ID in the user's session and updates all the calls we make to GOV.UK to use this ID.

Once this PR is merged we can safely change the subject ID returned to this app.