### PR TITLE
ATB-130 Switchover to using DynamoDB for sessions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1412,40 +1412,23 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
-        AttributeDefinition:
         - AttributeName: "id"
           AttributeType: "S"
-        - AttributeName: "expires"
-          AttributeType: "N"
-        - AttributeName: "type"
+        - AttributeName: "subjectId"
           AttributeType: "S"
-        - AttributeName: "sess"
-          AttributeType: "S"
-      #          AttributeName: "subjectId"
-      #          AttributeType: "S" - part of GSI
-      BillingMode: PROVISIONED
+      BillingMode: PAY_PER_REQUEST
       ContributorInsightsSpecification:
         Enabled: true
-      #      GlobalSecondaryIndexes: # Karla - not just primary key indexing - TBC
-      #        IndexName: subjectIdIndex
-      #        KeySchema: HASH
-      #        Projection:
-      #          ProjectionType: KEYS_ONLY
-      #        ProvisionedThroughput:
-      #          ReadCapacityUnits: Integer
-      #          WriteCapacityUnits: Integer
-      # ImportSourceSpecification: #properties of data being imported from the S3 bucket to table.
-      #        InputCompressionType: String #GZIP | NONE | ZSTD ???
-      #        InputFormat: String  # CSV | >DYNAMODB_JSON<  | ION
-      #        InputFormatOptions:
-      #        Csv:
-      #          Csv #Figure out later?
+      GlobalSecondaryIndexes:
+        - IndexName: "subjectIdIndex"
+          KeySchema:
+            - AttributeName: "subjectId"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: KEYS_ONLY
       KeySchema:
-        AttributeName: "id"
-        KeyType: "HASH"
-      ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
+        - AttributeName: "id"
+          KeyType: "HASH"
       SSESpecification:
         KMSMasterKeyId: !Ref DynamoDBKmsKey
         SSEEnabled: true
@@ -1465,10 +1448,6 @@ Resources:
           Value: !Ref SourceTagValue
         - Key: Application
           Value: Shared
-  #      TimeToLiveSpecification:
-  #        AttributeName: String
-  #        Enabled: Boolean #KARLA - Sessions to be deleted or not?
-
 
   DynamoDBKmsKey:
     Type: AWS::KMS::Key
@@ -1495,9 +1474,9 @@ Resources:
               - "kms:GenerateDataKey*"
               - "kms:Describe*"
             Resource: "*"
-#            Condition:
-#              ArnLike:
-#                aws:SourceArn: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:secret:/${AWS::StackName}/Config/Session/secret"
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:/${AWS::StackName}"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -555,8 +555,7 @@ Resources:
                   !Ref Environment,
                   ANALYTICSCOOKIEDOMAIN,
                 ]
-              Value: !FindInMap [EnvironmentVariables, !Ref Environment, ANALYTICSCOOKIEDOMAIN ]
-            - Name: "SESSION_TABLE_NAME" #Env for dynamoDb
+            - Name: "SESSION_TABLE_NAME"
               Value: !Ref SessionsDynamoDB
             - Name: "REDIS_KEY"
               Value: !Ref RedisStackName

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1405,6 +1405,124 @@ Resources:
                 "aws:SecureTransport": true
 
   #
+  # DynamoDB
+  #
+
+  SessionsDynamoDB:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        AttributeDefinition:
+        -
+          AttributeName: "id"
+          AttributeType: "S"
+        -
+          AttributeName: "expires"
+          AttributeType: "N"
+        -
+          AttributeName: "type"
+          AttributeType: "S"
+        -
+          AttributeName: "sess"
+          AttributeType: "S"
+      #          AttributeName: "subjectId"
+      #          AttributeType: "S" - part of GSI
+      BillingMode: PROVISIONED
+      ContributorInsightsSpecification:
+        Enabled: true
+      #      GlobalSecondaryIndexes: # Karla - not just primary key indexing - TBC
+      #        IndexName: subjectIdIndex
+      #        KeySchema: HASH
+      #        Projection:
+      #          ProjectionType: KEYS_ONLY
+      #        ProvisionedThroughput:
+      #          ReadCapacityUnits: Integer
+      #          WriteCapacityUnits: Integer
+      # ImportSourceSpecification: #properties of data being imported from the S3 bucket to table.
+      #        InputCompressionType: String #GZIP | NONE | ZSTD ???
+      #        InputFormat: String  # CSV | >DYNAMODB_JSON<  | ION
+      #        InputFormatOptions:
+      #        Csv:
+      #          Csv #Figure out later?
+      KeySchema:
+        AttributeName: "id"
+        KeyType: "HASH"
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+      SSESpecification:
+        KMSMasterKeyId: !Ref DynamoDBKmsKey
+        SSEEnabled: true
+        SSEType: KMS
+      TableClass: STANDARD
+      TableName: !Sub ${AWS::StackName}-SessionsDynamoDB
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: Accounts
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+        - Key: Application
+          Value: Shared
+  #      TimeToLiveSpecification:
+  #        AttributeName: String
+  #        Enabled: Boolean #KARLA - Sessions to be deleted or not?
+
+
+  DynamoDBKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: !Sub "KMS key used to protect DynamoDB data in ${AWS::StackName}"
+      Enabled: true
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: !Sub "dynamodb.amazonaws.com"
+            Action:
+              - "kms:Encrypt*"
+              - "kms:Decrypt*"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:Describe*"
+            Resource: "*"
+#            Condition:
+#              ArnLike:
+#                aws:SourceArn: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:secret:/${AWS::StackName}/Config/Session/secret"
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-DynamoDBKmsKey"
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  DynamoDBKmsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}-DynamoDBKmsKey"
+      TargetKeyId: !GetAtt DynamoDBKmsKey.Arn
+
+  #
   # Outputs
   #
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1413,17 +1413,13 @@ Resources:
     Properties:
       AttributeDefinitions:
         AttributeDefinition:
-        -
-          AttributeName: "id"
+        - AttributeName: "id"
           AttributeType: "S"
-        -
-          AttributeName: "expires"
+        - AttributeName: "expires"
           AttributeType: "N"
-        -
-          AttributeName: "type"
+        - AttributeName: "type"
           AttributeType: "S"
-        -
-          AttributeName: "sess"
+        - AttributeName: "sess"
           AttributeType: "S"
       #          AttributeName: "subjectId"
       #          AttributeType: "S" - part of GSI

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -55,10 +55,14 @@ Parameters:
   VpcStackName:
     Description: The name of the stack that defines the VPC in which this container will run.
     Type: String
-  RedisStackName:
-    Description: The name of the stack that defines the Redis cluster
+#  RedisStackName:
+#    Description: The name of the stack that defines the Redis cluster
+#    Type: String
+#    Default: shared-redis
+  DynamoDBStackName:
+    Description: The name of the stack that defines the DynamoDB table
     Type: String
-    Default: shared-redis
+    Default: DynamoDB
   BackendStackName:
     Description: The name of the backend stack
     Type: String
@@ -307,6 +311,15 @@ Resources:
                   - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:/${RedisStackName}/Cluster/Password"
               - Effect: Allow
                 Action:
+                  - "dynamodb:GetItem"
+                  - "dynamodb:PutItem"
+                  - "dynamodb:DeleteItem"
+                  - "dynamodb:Query"
+                  - "dynamodb:DeleteItem"
+                  - "dynamodb:UpdateItem"
+                Resource: !GetAtt SessionsDynamoDB.Arn
+              - Effect: Allow
+                Action:
                   - dynamodb:Query
                   - dynamodb:GetItem
                 Resource:
@@ -539,6 +552,9 @@ Resources:
                   !Ref Environment,
                   ANALYTICSCOOKIEDOMAIN,
                 ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, ANALYTICSCOOKIEDOMAIN ]
+            - Name: "SESSION_TABLE_NAME" #Env for dynamoDb
+              Value: !Ref SessionsDynamoDB
             - Name: "REDIS_KEY"
               Value: !Ref RedisStackName
             - Name: "KMS_KEY_ID"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -311,11 +311,14 @@ Resources:
                   - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:/${RedisStackName}/Cluster/Password"
               - Effect: Allow
                 Action:
+                  - "dynamodb:DescribeTable"
                   - "dynamodb:GetItem"
+                  - "dynamodb:BatchGetItem"
                   - "dynamodb:PutItem"
+                  - "dynamodb:BatchWriteItem"
                   - "dynamodb:DeleteItem"
                   - "dynamodb:Query"
-                  - "dynamodb:DeleteItem"
+                  - "dynamodb.Scan"
                   - "dynamodb:UpdateItem"
                 Resource: !GetAtt SessionsDynamoDB.Arn
               - Effect: Allow


### PR DESCRIPTION
### What ?
To switch over the session store on the account management app to use DynamoDB instead of Shared-Redis by adding new environment variables, DynamoDB permissions, and creating a DynamoDB table that uses KMS keys. 

### Why?
To facilitate the switchover from Redis to DynamoDB for session store.

•Note :  Infrastructure work can also be seen in Karla's PR  as part of the merge- branch >  ATB-108-store-sessions-in-dynamodbv3 
