### PR TITLE
GUA-568: Implement content updates for delete page

### DIFF
--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -12,22 +12,13 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0">{{'pages.deleteAccount.header' | translate}}</h1>
 
 <p class="govuk-body">{{'pages.deleteAccount.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.deleteAccount.paragraph2' | translate}}</p>
+<p class="govuk-body">{{'pages.deleteAccount.paragraph3' | translate | safe | replace("[emailManagementLink]", manageEmailsLink)}}</p>
+<p class="govuk-body">{{'pages.deleteAccount.paragraph4' | translate}}</p>
+<p class="govuk-body">{{'pages.deleteAccount.paragraph5' | translate}}</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>{{ 'pages.deleteAccount.listItem1' | translate }}</li>
-  <li>{{ 'pages.deleteAccount.listItem2'
-    | translate
-    | replace("[emailManagementLink]", manageEmailsLink)
-    | safe
-  }}</li>
-  <li>{{ 'pages.deleteAccount.listItem3' | translate }}</li>
-</ul>
-<p class="govuk-body">{{ 'pages.deleteAccount.paragraph2' | translate }}</p>
-<p class="govuk-body">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
-
-{{ govukDetails({
-  summaryText: 'pages.deleteAccount.details.summaryText' | translate,
-  html: 'pages.deleteAccount.details.text' | translate
+{{ govukInsetText({
+  text: 'pages.deleteAccount.insetText' | translate
 }) }}
 
 <form action="/delete-account" method="post" novalidate>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -300,18 +300,14 @@
     "deleteAccount": {
       "title": "Ydych chi’n siwr eich bod am ddileu eich cyfrif GOV.UK?",
       "header": "Ydych chi’n siwr eich bod am ddileu eich cyfrif GOV.UK?",
-      "paragraph1": "Bydd hyn yn:",
-      "listItem1": "dileu eich cyfrif GOV.UK yn barhaol a’r wybodaeth sydd wedi’i gadw ynddo",
-      "listItem2": "dileu unrhyw <a class=\"govuk-link\" href=\"[emailManagementLink]\">Tanysgrifiadau e-bost GOV.UK</a> y gallai fod gennych",
-      "listItem3": "tynnu i ffwrdd eich gallu i fewngofnodi i LITE (i wneud cais am drwyddedau allforio ar gyfer nwyddau rheoledig), os ydych wedi’i ddefnyddio gyda’ch cyfrif GOV.UK",
-      "paragraph2": "Os byddwch angen cyfrif GOV.UK yn y dyfodol, bydd yn rhaid i chi greu un newydd.",
-      "paragraph3": "Ni fydd dileu eich cyfrif GOV.UK yn dileu unrhyw gyfrifon eraill y llywodraeth sydd gennych, fel Porth y Llywodraeth neu Gredyd Cynhwysol.",
-      "details": {
-        "summaryText": "Os ydych yn defnyddio LITE",
-        "text": "<p class=\"govuk-body\">Os ydych yn dileu eich cyfrif GOV.UK ni fyddwch mwyach yn gallu mewngofnodi i LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol).</p><p class=\"govuk-body\"> Ni fydd y wybodaeth amdanoch a gedwir yn LITE yn cael ei ddileu. E-bostiwch <a class=\"govuk-link\" href=\"mailto:data.protection@trade.gov.uk\">data.protection@trade.gov.uk</a> os ydych chi am ddileu gwybodaeth a gedwir gan LITE.</p>"
-      },
+      "paragraph1": "Bydd hyn yn dileu y manylion mewngofnodi ar gyfer eich cyfrif GOV.UK yn barhaol.",
+      "paragraph2": "Mae hyn yn golygu na fyddwch yn gallu mewngofnodi mwyach i'r gwasanaethau rydych yn eu defnyddio gyda'ch cyfrif GOV.UK.",
+      "paragraph3": "Os oes gennych <a class=\"govuk-link\" href=\"[emailManagementLink]\">danysgrifiadau e-byst GOV.UK</a>, bydd y rhain hefyd yn cael eu dileu.",
+      "paragraph4": "Ni fydd yn dileu'r wybodaeth bersonol a gedwir gan wasanaethau rydych wedi'u defnyddio gyda'ch cyfrif GOV.UK.",
+      "paragraph5": "Os byddwch angen cyfrif GOV.UK yn y dyfodol, bydd yn rhaid i chi greu un newydd.",
+      "insetText": "Ni fydd dileu eich cyfrif GOV.UK yn effeithio ar unrhyw gyfrifon eraill y llywodraeth y gallai fod gennych, fel Porth y Llywodraeth neu Gredyd Cynhwysol.",
       "deleteAccount": "Dileu eich cyfrif GOV.UK",
-      "doNotDeleteAccount": "Canslo a mynd yn ôl i’ch cyfrif"
+      "doNotDeleteAccount": "Canslo a mynd yn ôl i gosodiadau"
     },
     "changePhoneNumber": {
       "title": "Rhowch eich rhif ffôn symudol newydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -300,18 +300,14 @@
     "deleteAccount": {
       "title": "Are you sure you want to delete your GOV.UK account?",
       "header": "Are you sure you want to delete your GOV.UK account?",
-      "paragraph1": "This will:",
-      "listItem1": "permanently delete your GOV.UK account and the information stored in it",
-      "listItem2": "delete any <a class=\"govuk-link\" href=\"[emailManagementLink]\">GOV.UK email subscriptions</a> you may have",
-      "listItem3": "remove your ability to sign in to LITE (to apply for export licences for controlled goods), if you’ve used it with your GOV.UK account",
-      "paragraph2": "If you need a GOV.UK account in the future, you’ll have to create a new one.",
-      "paragraph3": "Deleting your GOV.UK account will not delete any other government accounts you may have, such as Government Gateway or Universal Credit.",
-      "details": {
-        "summaryText": "If you use LITE",
-        "text": "<p class=\"govuk-body\">If you delete your GOV.UK account you will no longer be able to sign in to LITE (Licensing for International Trade and Enterprise).</p><p class=\"govuk-body\"> The information about you held in LITE will not be deleted. Email <a class=\"govuk-link\" href=\"mailto:data.protection@trade.gov.uk\">data.protection@trade.gov.uk</a> if you want to delete information held by LITE.</p>"
-      },
+      "paragraph1": "This will permanently delete the sign in details for your GOV.UK account.",
+      "paragraph2": "This means you’ll no longer be able to sign in to the services you access with your GOV.UK account.",
+      "paragraph3": "If you have <a class=\"govuk-link\" href=\"[emailManagementLink]\">GOV.UK email subscriptions</a>, these will also be deleted.",
+      "paragraph4": "It will not delete the personal information held by services you’ve used with your GOV.UK account.",
+      "paragraph5": "If you need a GOV.UK account in the future, you’ll have to create a new one.",
+      "insetText": "Deleting your GOV.UK account will not affect any other government accounts you may have, such as Government Gateway or Universal Credit.",
       "deleteAccount": "Delete your GOV.UK account",
-      "doNotDeleteAccount": "Cancel and go back to your account"
+      "doNotDeleteAccount": "Cancel and go back to settings"
     },
     "changePhoneNumber": {
       "title": "Enter your new mobile phone number",


### PR DESCRIPTION
Update content on the Delete your account page to bring it in line with the [latest Figma design](https://www.figma.com/file/Q6n44LmHFsCOGzZ44QTW4U/Account-home?node-id=3433%3A21903&t=fr9jXe6SJaPcSpo4-0). This is part of a series of changes to support the launch of the service dashboard.

~**WELSH content to be added as soon as we get back translations**~ Done

------

 
### Before
<img width="1792" alt="Screenshot 2022-12-07 at 16 03 10" src="https://user-images.githubusercontent.com/7116819/206229437-b346f0e8-c04d-420e-92ee-eba23d57f8dd.png">

### After
<img width="1792" alt="Screenshot 2022-12-07 at 14 09 01" src="https://user-images.githubusercontent.com/7116819/206229426-1a2485ce-2cde-416f-a880-7c67ba7b58e8.png">
