### PR TITLE
BAU: fix header/nav issues

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -111,12 +111,25 @@ $govuk-new-link-styles: true;
   background-color: govuk-colour("light-grey", $legacy: "grey-3");
 }
 
+// the modifier below is in place to remove the non-optional blue border at the bottom of the Design System header component
+// this is not ideal, however since there is no option/flag to remove the border from the component, it is the only way
+.govuk-header--with-account-navigation {
+  border-bottom: 0;
+
+  .govuk-header__container {
+    margin-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .govuk-header__logo {
+    float: left;
+    width: 100%;
+  }
+}
+
 .account-navigation {
   background-color: govuk-colour("light-grey");
   border-bottom: 1px solid $govuk-border-colour;
-  // this is a hack and not very nice
-  // the DS header comes with a non-optional border on the bottom, annoyingly
-  margin-top: -(govuk-spacing(2));
   position: relative;
 }
 

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -36,7 +36,8 @@
   {% if supportNewAccountHeader %}
     {{ govukHeader({
       homepageUrl: 'general.header.homepageHref' | translate,
-      productName: 'general.header.productName' | translate
+      productName: 'general.header.productName' | translate,
+      classes: "govuk-header--with-account-navigation" if not hideSignOutLink
     }) }}
     {% if not hideSignOutLink %}
       {% include 'common/layout/navigation.njk' %}


### PR DESCRIPTION
Firefox doesn't like the double negative margins between the DS header and the new account nav which is leading to some bizzare behaviour when zooming in and out where the nav links are jumping to the left/right at different zoom levels on Firefox.

This implements an alternative solution which instead of hiding the blue border at the bottom of the black bar by adding negative margins to the account nav, uses a modifier class which removes the bar and negative margins at the bottom of the header.

Also makes the container for the GOVUK logo and Account product name take up 100% of the width of the containing element. It was spotted that the "Account" product name collapses below the logo on certain breakpoints. Increasing the width of the container ensures this will not happen.


### Issue tracking

[GUA-575](https://govukverify.atlassian.net/browse/GUA-575)
