### PR TITLE
GUA-522: Update dataLayer push with language

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -122,6 +122,25 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     initGtm();
   }
 
+  function pushLanguageToDataLayer() {
+    var languageCode = document.querySelector('html') &&
+        document.querySelector('html').getAttribute('lang');
+
+    var languageNames = {
+      'en':'english',
+      'cy':'welsh'
+    }
+
+    if (languageCode && languageNames[languageCode]) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "langEvent",        
+        language: languageNames[languageCode],
+        languagecode: languageCode
+      });
+    }
+  }
+
   function loadGtmScript() {
     var gtmScriptTag = document.createElement("script");
     gtmScriptTag.type = "text/javascript";
@@ -165,6 +184,7 @@ var cookies = function (trackingId, analyticsCookieDomain) {
       dataLayer.push(obj);
     }
 
+    pushLanguageToDataLayer();
     gtag({ "gtm.start": new Date().getTime(), event: "gtm.js" });
 
     var govAccountsLink = document.getElementById("gov-uk-accounts-link");


### PR DESCRIPTION
Push language and language code to the data layer as per PA request. This is so Performance Analysts have access to information on the currently selected language in GA.

I shamelessly copied the [current implementation](https://github.com/alphagov/di-authentication-frontend/blob/main/src/assets/javascript/cookies.js#L113) on `di-authentication-frontend` as we want our implementation of this to work exactly the same.