### PR TITLE
[ATB-163] Fix SAM Validate issue by using python cryptography dependancy version 38.0.4

### DIFF
--- a/.github/workflows/validate-sam-template.yml
+++ b/.github/workflows/validate-sam-template.yml
@@ -42,6 +42,9 @@ jobs:
 
       - name: Set up SAM cli
         uses: aws-actions/setup-sam@v2
+        
+      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
+        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
 
       - name: Set up AWS creds
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Proposed changes

### What changed

Limit the python cryptography dependancy to version 38.0.4.

### Why did it change

Build is pulling the latest python cryptography version 39.0.0 and this version no longer supports openssl version 1.1.0 or older.

### Issue tracking

[GitHub issue](https://github.com/aws/aws-sam-cli/issues/4527)
[Jira issue](https://govukverify.atlassian.net/browse/ATB-163)

## Checklists
[Successful build](https://github.com/alphagov/di-authentication-account-management/actions/runs/3829416921)

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed