### PR TITLE
GUA-549: Content update on /session-expired

### DIFF
--- a/src/components/session-expired/index.njk
+++ b/src/components/session-expired/index.njk
@@ -8,6 +8,10 @@
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">{{ 'error.timeoutError.header' | translate }}</h1>
             <p class="govuk-body">{{ 'error.timeoutError.content.paragraph1' | translate }}</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>{{ 'error.timeoutError.content.listItem1' | translate }}</li>
+                <li>{{ 'error.timeoutError.content.listItem2' | translate }}</li>
+            </ul>
             <p class="govuk-body">{{ 'error.timeoutError.content.paragraph2' | translate }}</p>
         </div>
     </div>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -110,8 +110,10 @@
       "title": "Rydych wedi cael eich allgofnodi",
       "header": "Rydych wedi cael eich allgofnodi",
       "content": {
-        "paragraph1": "Rydych wedi cael eich allgofnodi oherwydd nad oeddech wedi defnyddio eich cyfrif am fwy na 2 awr.",
-        "paragraph2": "Mae hyn er mwyn cadw eich cyfrif a’ch gwybodaeth yn ddiogel.",
+        "paragraph1": "Gallai hyn fod oherwydd rydych:",
+        "listItem1": "heb ddefnyddio eich cyfrif am fwy na 2 awr",
+        "listItem2": "wedi allgofnodi o'ch cyfrif tra'n defnyddio gwasanaeth arall",
+        "paragraph2": "Rydym wedi eich allgofnodi i gadw eich cyfrif a'ch gwybodaeth yn ddiogel.",
         "signInButtonText": "Mewngofnodi i’ch cyfrif",
         "govUKHomepageLink": "https://www.gov.uk/",
         "govUKHomepageLinkText": "Ewch i hafan GOV.UK"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -107,11 +107,13 @@
       }
     },
     "timeoutError": {
-      "title": "You have been signed out",
-      "header": "You have been signed out",
+      "title": "You’ve been signed out",
+      "header": "You’ve been signed out",
       "content": {
-        "paragraph1": "You’ve been signed out because you did not use your account for more than 2 hours.",
-        "paragraph2": "This is to keep your account and your information secure.",
+        "paragraph1": "This could be because you:",
+        "listItem1": "have not used your account for more than 2 hours",
+        "listItem2": "signed out of your account while using another service",
+        "paragraph2": "We signed you out to keep your account and your information secure.",
         "signInButtonText": "Sign in to your account",
         "govUKHomepageLink": "https://www.gov.uk/",
         "govUKHomepageLinkText": "Go to the GOV.UK homepage"


### PR DESCRIPTION
Update the content on the "You have been signed out" page to provide more clarity as to the reasons the session might have ended.

It would be cool to show different content depending on why the user’s been signed out, but that would be more work than this really justifies at the moment. So instead we are listing all the reasons the user might have been signed out:
- have not used your account for more than 2 hours 
- signed out of your account while using another service