### PR TITLE
BAU: Fix page heading/title on Settings page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -122,8 +122,8 @@
   },
   "pages": {
     "manageYourAccount": {
-      "title": "Eich cyfrif GOV.UK",
-      "header": "Eich cyfrif GOV.UK",
+      "title": "Gosodiadau",
+      "header": "Gosodiadau",
       "signedInStatus": "Rydych wedi mewngofnodi fel",
       "accountDetails": "Eich manylion mewngofnodi",
       "summaryList": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -122,8 +122,8 @@
   },
   "pages": {
     "manageYourAccount": {
-      "title": "Your GOV.UK account",
-      "header": "Your GOV.UK account",
+      "title": "Settings",
+      "header": "Settings",
       "signedInStatus": "You’re signed in as",
       "accountDetails": "Your sign in details",
       "summaryList": {


### PR DESCRIPTION
The title of this page seems to have reverted back to "Your GOV.UK account" although it was definitely "Settings" when we tested it previously.

This changes the name of the page back to what it should be.
