### PR TITLE
[AUT-911]: Shutdown Auth AM instances in build, integration and staging.

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -2,7 +2,8 @@ environment         = "build"
 your_account_url    = ""
 common_state_bucket = "digital-identity-dev-tfstate"
 
-account_management_auto_scaling_enabled = true
+account_management_auto_scaling_enabled = false
+account_management_ecs_desired_count    = 0
 
 support_language_cy = "1"
 

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -2,7 +2,8 @@ environment         = "integration"
 your_account_url    = "https://www.integration.publishing.service.gov.uk/account/home"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-account_management_auto_scaling_enabled = true
+account_management_auto_scaling_enabled = false
+account_management_ecs_desired_count    = 0
 
 support_language_cy = "1"
 

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -2,8 +2,9 @@ environment         = "staging"
 your_account_url    = "https://www.staging.publishing.service.gov.uk/account/home"
 common_state_bucket = "di-auth-staging-tfstate"
 
-account_management_auto_scaling_enabled = true
+account_management_auto_scaling_enabled = false
 support_language_cy                     = "1"
+account_management_ecs_desired_count    = 0
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## Proposed changes

Shutdown Auth AM instances in build, integration and staging.

### What changed

Set the ECS desired count to 0.
Switch off autoscaling so the min and max counts do not override the desired count.

### Why did it change

These have been replaced by Accounts team instances and there are no longer any dependencies on them in the Auth acceptance tests.

### Issue tracking

https://govukverify.atlassian.net/browse/AUT-911
