### PR TITLE
BAU: minor tweak to nav link focus state

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -150,11 +150,16 @@ $govuk-new-link-styles: true;
   }
 }
 
+$nav-link-padding: govuk-spacing(3);
+$nav-link-outline-thickness: 2px;
+$nav-active-border-thickness: 5px;
+
 .account-navigation__link {
   @extend .govuk-link;
   display: inline-block;
   font-weight: bold;
-  padding: govuk-spacing(3) 0;
+  padding: $nav-link-padding - $nav-link-outline-thickness 0 $nav-link-padding;
+  margin-top: $nav-link-outline-thickness;
   
   &:not(:hover) {
     text-decoration: none;
@@ -173,13 +178,12 @@ $govuk-new-link-styles: true;
   }
 
   .account-navigation__list-item--active & {
-    padding: govuk-spacing(3) 0 govuk-spacing(2);
-    border-bottom: 5px solid;
-    border-color: govuk-colour("blue");
+    padding: $nav-link-padding - $nav-link-outline-thickness 0 $nav-link-padding - $nav-active-border-thickness;
+    border-bottom: $nav-active-border-thickness solid $govuk-link-colour;
 
     &:focus {
       border-bottom: none;
-      padding: govuk-spacing(3) 0;
+      padding: $nav-link-padding - $nav-link-outline-thickness 0 $nav-link-padding;
     }
 
     &:hover {


### PR DESCRIPTION
## Proposed changes
The yellow background/outline of the link slightly overflows the boundaries of its container when the link is in focus. This is not necessarily on purpose and doesn't necessarily look great.

This fixes the issue, also replacing some hard coded values in the code with SASS variables.

### What changed

#### Before
<img width="690" alt="Screenshot 2023-01-13 at 15 04 11" src="https://user-images.githubusercontent.com/7116819/212371630-f229d2e2-0ada-49f7-b6dc-aa62ebe67abd.png">

#### After
<img width="699" alt="Screenshot 2023-01-13 at 15 03 05" src="https://user-images.githubusercontent.com/7116819/212371621-a77c8e40-f941-4063-85db-ac668c035b72.png">


https://govukverify.atlassian.net/browse/GUA-624
