### PR TITLE
GUA-612: change phone number journey content updates

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -75,6 +75,7 @@ export const PATH_DATA: {
   HEALTHCHECK: { url: "/healthcheck" },
   GLOBAL_LOGOUT: { url: "/global-logout" },
   RESEND_EMAIL_CODE: { url: "/resend-email-code" },
+  RESEND_PHONE_CODE: { url: "/resend-phone-code" },
 };
 
 export const API_ENDPOINTS = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -59,6 +59,7 @@ import { globalLogoutRouter } from "./components/global-logout/global-logout-rou
 import { subjectSessionIndex } from "./utils/subject-session-index";
 import { subjectSessionIndexMiddleware } from "./middleware/subject-session-index-middleware";
 import { resendEmailCodeRouter } from "./components/resend-email-code/resend-email-code-routes";
+import { resendPhoneCodeRouter } from "./components/resend-phone-code/resend-phone-code-routes";
 import { redirectsRouter } from "./components/redirects/redirects-routes"
 
 const APP_VIEWS = [
@@ -156,6 +157,7 @@ async function createApp(): Promise<express.Application> {
   app.use(sessionExpiredRouter);
   app.use(signedOutRouter);
   app.use(resendEmailCodeRouter);
+  app.use(resendPhoneCodeRouter);
 
   // Router for all previously used URLs, that we want to redirect on
   // No URL left behind policy

--- a/src/components/change-phone-number/index.njk
+++ b/src/components/change-phone-number/index.njk
@@ -18,6 +18,7 @@
   <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}" />
 
   <p class="govuk-body">{{'pages.changePhoneNumber.info.paragraph1' | translate}}</p>
+  <p class="govuk-body">{{'pages.changePhoneNumber.info.paragraph2' | translate}}</p>
 
   {{ govukInput({
   label: {

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -16,6 +16,8 @@ const TEMPLATE_NAME = "check-your-phone/index.njk";
 export function checkYourPhoneGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
     phoneNumber: redactPhoneNumber(req.session.user.newPhoneNumber),
+    resendCodeLink: PATH_DATA.RESEND_PHONE_CODE.url,
+    changePhoneNumberLink: PATH_DATA.CHANGE_PHONE_NUMBER.url
   });
 }
 

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -12,43 +12,42 @@
     {% include "common/errors/errorSummary.njk" %}
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate}}</h1>
-
-    <p class="govuk-body">{{'pages.checkYourPhone.text' | translate | replace("[mobile]", phoneNumber )}}</p>
+    {{ govukInsetText({
+        text: 'pages.checkYourPhone.text' | translate | replace("[mobile]", phoneNumber)
+    })}}
 
     <p class="govuk-body">{{'pages.checkYourPhone.info.paragraph' | translate}}</p>
 
     <form action="/check-your-phone" method="post" novalidate="novalidate">
-
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
         <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
         {{ govukInput({
-    label: {
-        text: 'pages.checkYourPhone.code.label' | translate
-    },
-    classes:"govuk-input--width-5",
-    id: "code",
-    name: "code",
-    inputmode: "numeric",
-    spellcheck: false,
-    errorMessage: {
-        text: errors['code'].text
-    } if (errors['code'])})
-}}
+            label: {
+                text: 'pages.checkYourPhone.code.label' | translate
+            },
+            classes:"govuk-input--width-5",
+            id: "code",
+            name: "code",
+            inputmode: "numeric",
+            spellcheck: false,
+            errorMessage: {
+                text: errors['code'].text
+            } if (errors['code'])})
+        }}
+
+        {% set detailsHTML %}
+            <p class="govuk-body">{{'pages.checkYourPhone.details.text' | translate | replace("[resendCodeLink]", resendCodeLink) | replace("[changePhoneNumberLink]", changePhoneNumberLink) | safe }}</p>
+        {% endset %}
+
+        {{ govukDetails({
+            summaryText: 'pages.checkYourPhone.details.summaryText' | translate,
+            html: detailsHTML
+        }) }}
 
         {{ govukButton({
-    "text": button_text|default("general.continue.label" | translate, true),
-    "type": "Submit",
-    "preventDoubleClick": true
-}) }}
-
+            "text": button_text|default("general.continue.label" | translate, true),
+            "type": "Submit",
+            "preventDoubleClick": true
+        }) }}
     </form>
-    <p class="govuk-body">
-        <a href="/request-new-opt-code" class="govuk-link govuk-body" rel="noreferrer noopener">{{'pages.checkYourPhone.info.requestNewCodeLink' | translate }}</a>
-        {{'pages.checkYourPhone.info.requestNewCodeParagraph' | translate }}
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.checkYourPhone.info.requestNewCodeReason1' | translate}}</li>
-        <li>{{ 'pages.checkYourPhone.info.requestNewCodeReason2' | translate}}</li>
-    </ul>
 {% endblock %}

--- a/src/components/resend-phone-code/index.njk
+++ b/src/components/resend-phone-code/index.njk
@@ -1,0 +1,26 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageTitleName = 'pages.resendMfaCode.title' | translate %}
+
+{% block content %}
+    <form action="/resend-phone-code" method="post" novalidate="novalidate">
+      <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+      <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+
+      <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate}}</h1>
+
+      {{ govukInsetText({
+          text: 'pages.resendMfaCode.phoneNumber.insetText' | translate | replace("[mobile]", phoneNumberRedacted )
+      }) }}
+
+      <p class="govuk-body">{{'pages.resendMfaCode.phoneNumber.paragraph' | translate}}</p>
+
+      {{ govukButton({
+          "text": 'pages.resendMfaCode.continue' | translate,
+          "type": "Submit",
+          "preventDoubleClick": true
+      }) }}
+    </form>
+{% endblock %}

--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -1,0 +1,64 @@
+import { Request, Response } from "express";
+import { ERROR_CODES, PATH_DATA } from "../../app.constants";
+import { redactPhoneNumber } from "../../utils/strings";
+import { ExpressRouteFunc } from "../../types";
+import { ChangePhoneNumberServiceInterface } from "../change-phone-number/types";
+import { changePhoneNumberService } from "../change-phone-number/change-phone-number-service";
+import { BadRequestError } from "../../utils/errors";
+import { getNextState } from "../../utils/state-machine";
+import xss from "xss";
+import {
+  formatValidationError,
+  renderBadRequest,
+} from "../../utils/validation";
+
+const TEMPLATE_NAME = "resend-phone-code/index.njk";
+
+export function resendPhoneCodeGet(req: Request, res: Response): void {
+  res.render(TEMPLATE_NAME, {
+    phoneNumberRedacted: redactPhoneNumber(req.session.user.newPhoneNumber),
+    phoneNumber: req.session.user.newPhoneNumber
+  });
+}
+
+export function resendPhoneCodePost(
+  service: ChangePhoneNumberServiceInterface = changePhoneNumberService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { email } = req.session.user;
+    const { accessToken } = req.session.user.tokens;
+    const newPhoneNumber = req.body.phoneNumber;
+    const response = await service.sendPhoneVerificationNotification(
+      accessToken,
+      email,
+      newPhoneNumber,
+      req.ip,
+      res.locals.sessionId,
+      res.locals.persistentSessionId,
+      xss(req.cookies.lng as string)
+    );
+
+    if (response.success) {
+      req.session.user.newPhoneNumber = newPhoneNumber;
+
+      req.session.user.state.changePhoneNumber = getNextState(
+        req.session.user.state.changePhoneNumber.value,
+        "VERIFY_CODE_SENT"
+      );
+
+      return res.redirect(PATH_DATA.CHECK_YOUR_PHONE.url);
+    }
+
+    if (response.code === ERROR_CODES.NEW_PHONE_NUMBER_SAME_AS_EXISTING) {
+      const error = formatValidationError(
+        "phoneNumber",
+        req.t(
+          "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
+        )
+      );
+      return renderBadRequest(res, req, TEMPLATE_NAME, error);
+    } else {
+      throw new BadRequestError(response.message, response.code);
+    }
+  };
+}

--- a/src/components/resend-phone-code/resend-phone-code-routes.ts
+++ b/src/components/resend-phone-code/resend-phone-code-routes.ts
@@ -1,0 +1,29 @@
+import * as express from "express";
+import { PATH_DATA } from "../../app.constants";
+
+import {
+  resendPhoneCodeGet,
+  resendPhoneCodePost
+} from "./resend-phone-code-controller";
+import { asyncHandler } from "../../utils/async";
+import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
+import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
+import { validateChangePhoneNumberRequest } from "../change-phone-number/change-phone-number-validation";
+
+const router = express.Router();
+
+router.get(
+  PATH_DATA.RESEND_PHONE_CODE.url,
+  requiresAuthMiddleware,
+  resendPhoneCodeGet
+);
+
+router.post(
+  PATH_DATA.RESEND_PHONE_CODE.url,
+  requiresAuthMiddleware,
+  validateChangePhoneNumberRequest(),
+  refreshTokenMiddleware(),
+  asyncHandler(resendPhoneCodePost())
+);
+
+export { router as resendPhoneCodeRouter };

--- a/src/components/resend-phone-code/tests/resend-phone-code-controller.test.ts
+++ b/src/components/resend-phone-code/tests/resend-phone-code-controller.test.ts
@@ -1,0 +1,75 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { ChangePhoneNumberServiceInterface } from "../../change-phone-number/types";
+import { getInitialState } from "../../../utils/state-machine";
+
+import {
+  resendPhoneCodeGet,
+  resendPhoneCodePost
+} from "../resend-phone-code-controller";
+
+describe("resend phone code controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    req = {
+      body: {},
+      session: { user: {} },
+      cookies: { lng: "en" },
+      i18n: { language: "en" },
+    };
+    res = {
+      render: sandbox.fake(),
+      redirect: sandbox.fake(),
+      status: sandbox.fake(),
+      locals: {},
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("resendPhoneCodeGet", () => {
+    it("should render resend phone code view", () => {
+      req.session.user = {
+        newPhoneNumber: "07111111111",
+      };
+      resendPhoneCodeGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("resend-phone-code/index.njk", {
+        phoneNumberRedacted: '*******1111',
+        phoneNumber: "07111111111",
+      });
+    });
+  });
+
+  describe("resendPhoneCodePost", () => {
+    it("should redirect to /check-your-phone when Get security code is clicked", async () => {
+      const fakeService: ChangePhoneNumberServiceInterface = {
+        sendPhoneVerificationNotification: sandbox.fake.returns({
+          success: true,
+        }),
+      };
+
+      res.locals.sessionId = "123456-djjad";
+      req.session.user.tokens = { accessToken: "token" };
+      req.body.phoneNumber = "+33645453322";
+      req.session.user.email = "test@test.com";
+      req.session.user.state = { changePhoneNumber: getInitialState() }
+
+      await resendPhoneCodePost(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.sendPhoneVerificationNotification).to.have.been
+        .calledOnce;
+      expect(res.redirect).to.have.calledWith("/check-your-phone");
+    });
+  });
+});

--- a/src/components/resend-phone-code/tests/resend-phone-code-integration.test.ts
+++ b/src/components/resend-phone-code/tests/resend-phone-code-integration.test.ts
@@ -1,0 +1,88 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import nock = require("nock");
+import decache from "decache";
+import { PATH_DATA } from "../../../app.constants";
+import { UnsecuredJWT } from "jose";
+
+describe("Integration:: request phone code", () => {
+  let sandbox: sinon.SinonSandbox;
+  let app: any;
+  const TEST_SUBJECT_ID = "jkduasd";
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/requires-auth-middleware");
+    const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
+    sandbox = sinon.createSandbox();
+    sandbox
+      .stub(sessionMiddleware, "requiresAuthMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        req.session.user = {
+          email: "test@test.com",
+          phoneNumber: "07839490040",
+          subjectId: TEST_SUBJECT_ID,
+          isAuthenticated: true,
+          state: {
+            changeEmail: {
+              value: "CHANGE_VALUE",
+              events: ["VALUE_UPDATED", "VERIFY_CODE_SENT"],
+            },
+          },
+          tokens: {
+            accessToken: new UnsecuredJWT({})
+              .setIssuedAt()
+              .setSubject("12345")
+              .setIssuer("urn:example:issuer")
+              .setAudience("urn:example:audience")
+              .setExpirationTime("2h")
+              .encode(),
+            idToken: "Idtoken",
+            refreshToken: "token",
+          },
+        };
+        next();
+      });
+
+    const oidc = require("../../../utils/oidc");
+    sandbox.stub(oidc, "getOIDCClient").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
+    app = await require("../../../app").createApp();
+
+    request(app).get(PATH_DATA.RESEND_PHONE_CODE.url);
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sandbox.restore();
+    app = undefined;
+  });
+
+  it("should return resend phone code page", (done) => {
+    request(app).get(PATH_DATA.RESEND_PHONE_CODE.url).expect(200, done);
+  });
+
+  it("should return error when csrf not present", (done) => {
+    request(app)
+      .post(PATH_DATA.RESEND_PHONE_CODE.url)
+      .type("form")
+      .send({
+        phoneNumber: "07839490040",
+      })
+      .expect(500, done);
+  });
+});

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -409,7 +409,7 @@
       "text": "Rydym wedi anfon e-bost at: ",
       "changeEmailLinkHref": "/change-email",
       "details": {
-        "summaryText": "Problemau gyda’r cod?",
+        "summaryText": "Problemau gyda’r cod",
         "text1": "Gallwn ",
         "sendCodeLinkText": "anfon y cod eto",
         "sendCodeLinkHref": "/request-new-email-code",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -437,11 +437,11 @@
       "header": "Gwiriwch eich ffôn",
       "text": "Rydym wedi anfon cod i [mobile].",
       "info": {
-        "paragraph": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud.",
-        "requestNewCodeLink": "Gofynnwch am god newydd",
-        "requestNewCodeParagraph": " os:",
-        "requestNewCodeReason1": "nad yw’r cod yn gweithio neu mae wedi dod i ben, neu ni wnaethoch dderbyn un",
-        "requestNewCodeReason2": "rydych eisiau defnyddio rhif ffôn gwahanol"
+        "paragraph": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
+      },
+      "details": {
+        "summaryText": "Problemau gyda'r cod",
+        "text": "Gallwn <a class=\"govuk-link\" href=\"[resendCodeLink]\">anfon y cod eto</a> neu gallwch <a class=\"govuk-link\" href=\"[changePhoneNumberLink]\">ddefnyddio rhif ffôn gwahanol</a>."
       },
       "code": {
         "label": "Rhowch y cod diogelwch 6 digid",
@@ -473,10 +473,11 @@
       "header": "Rhowch eich rhif ffôn symudol newydd",
       "info": {
         "paragraph1": "Byddwn yn anfon cod diogelwch 6 digid i’r rhif rydych yn ei roi i ni.",
+        "paragraph2":"Mae'n rhaid i chi ddefnyddio rhif ffôn symudol y DU.",
         "backLink": "Nid wyf eisiau newid fy rhif ffôn"
       },
       "ukPhoneNumber": {
-        "label": "Rhif ffôn y DU",
+        "label": "Rhif ffôn symudol y DU",
         "validationError": {
           "required": "Rhowch rif ffôn y DU",
           "international": "Rhowch rif ffôn y DU",
@@ -511,8 +512,8 @@
       "continue": "Cael cod diogelwch",
       "message": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd.",
       "phoneNumber": {
-        "default": "Byddwn yn anfon cod at y rhif ffôn sy'n gysylltiedig â'ch cyfrif",
-        "isResendCodeRequest": "Byddwn yn anfon cod i: [mobile]."
+        "insetText": "Byddwn yn anfon cod i: [mobile].",
+        "paragraph": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd."
       },
       "email": {
         "recipientMessage": "Byddwn yn anfon cod i: ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -435,13 +435,13 @@
     "checkYourPhone": {
       "title": "Check your phone",
       "header": "Check your phone",
-      "text": "We sent a code to [mobile].",
+      "text": "We have sent a code to [mobile].",
       "info": {
-        "paragraph": "It might take a few minutes to arrive. The code will expire after  15 minutes.",
-        "requestNewCodeLink": "Request a new code",
-        "requestNewCodeParagraph": " if:",
-        "requestNewCodeReason1": "the code isn’t working or has expired, or you didn’t receive one",
-        "requestNewCodeReason2": "you want to use a different phone number"
+        "paragraph": "It might take a few minutes to arrive. The code will expire after  15 minutes."
+      },
+      "details": {
+        "summaryText": "Problems with the code",
+        "text": "We can <a class=\"govuk-link\" href=\"[resendCodeLink]\">send the code again</a> or you can <a class=\"govuk-link\" href=\"[changePhoneNumberLink]\">use a different phone number</a>."
       },
       "code": {
         "label": "Enter the 6 digit security code",
@@ -471,10 +471,11 @@
       "header": "Enter your new mobile phone number",
       "info": {
         "paragraph1": "We will send a 6 digit security code to the number you give us.",
+        "paragraph2": "You must use a UK mobile phone number.",
         "backLink": "I do not want to change my phone number"
       },
       "ukPhoneNumber": {
-        "label": "UK phone number",
+        "label": "UK mobile phone number",
         "validationError": {
           "required": "Enter a UK phone number",
           "international": "Enter a UK phone number",
@@ -509,8 +510,8 @@
       "continue": "Get security code",
       "message": "Text messages can sometimes take a few minutes to arrive.",
       "phoneNumber": {
-        "default": "We will send a code to the phone number linked to your account",
-        "isResendCodeRequest": "We will send a code to: [mobile]."
+        "insetText": "We will send a code to [mobile]",
+        "paragraph": "Text messages can sometimes take a few minutes to arrive."
       },
       "email": {
         "recipientMessage": "We will send a code to: ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -409,7 +409,7 @@
       "text": "We have sent an email to: ",
       "changeEmailLinkHref": "/change-email",
       "details": {
-        "summaryText": "Problems with the code?",
+        "summaryText": "Problems with the code",
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
         "sendCodeLinkHref": "/resend-email-code",


### PR DESCRIPTION
### What changed

Implement content updates on the Change phone number journey. These are from designs from Auth which are on their Figma (journeys we inherited)

One of the things missing was an entire page (the resend phone code page). In addition to the content changes to bring us in line with Auth's figma, this also adds the missing page to the journey.

Ticket and figma for more details on what has been added:
https://govukverify.atlassian.net/browse/GUA-612 

https://www.figma.com/file/0JbNRTnq5ibRtfg8BMxXDL/Accounts-design-thinking?node-id=293%3A5816&t=YPbBpFCcTxj4eZrt-0

