### PR TITLE
BAU : Update json5 dependency as the previous version had a High Vuln…

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "uglify-js": "^3.14.3"
   },
   "resolutions": {
-    "minimist": "1.2.6"
+    "minimist": "1.2.6",
+    "json5": "2.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,11 +2240,9 @@ json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
 
-json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz"
-  dependencies:
-    minimist "^1.2.5"
+json5@2.2.3, json5@^2.1.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
 
 just-extend@^4.0.2:
   version "4.2.1"
@@ -2414,7 +2412,7 @@ minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@1.2.6, minimist@^1.2.5:
+minimist@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
 


### PR DESCRIPTION
- Upgrade json5 version to avoid vulnerability in version 2.1.2.
- The resolutions in package.json will help selective dependency upgrade which will be ignored when using yarn upgrade commands.