### PR TITLE
[ATB-207] Replaced var keyword with let or const

### DIFF
--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -1,4 +1,7 @@
-var onIntNumberSelected = function(intPhoneNumberCheckbox, phoneNumberInput) {
+const onIntNumberSelected = function (
+  intPhoneNumberCheckbox,
+  phoneNumberInput
+) {
   if (intPhoneNumberCheckbox.checked) {
     phoneNumberInput.value = "";
     phoneNumberInput.disabled = true;
@@ -10,13 +13,18 @@ var onIntNumberSelected = function(intPhoneNumberCheckbox, phoneNumberInput) {
 };
 
 function initChangePhoneNumber() {
-  var phoneNumberInput = document.querySelector('#phoneNumber');
+  const phoneNumberInput = document.querySelector("#phoneNumber");
   if (phoneNumberInput) {
-    var intPhoneNumberCheckbox = document.querySelector('#hasInternationalPhoneNumber');
-    intPhoneNumberCheckbox.addEventListener("click", function(event) {
+    const intPhoneNumberCheckbox = document.querySelector(
+      "#hasInternationalPhoneNumber"
+    );
+    intPhoneNumberCheckbox.addEventListener("click", function (event) {
       onIntNumberSelected(event.currentTarget, phoneNumberInput);
     });
-    window.addEventListener("load", onIntNumberSelected(intPhoneNumberCheckbox, phoneNumberInput));
+    window.addEventListener(
+      "load",
+      onIntNumberSelected(intPhoneNumberCheckbox, phoneNumberInput)
+    );
   }
 }
 initChangePhoneNumber();
@@ -26,7 +34,7 @@ initChangePhoneNumber();
   function appInit(trackingId, analyticsCookieDomain) {
     window.GOVUKFrontend.initAll();
 
-    var cookies = window.GOVSignIn.Cookies(trackingId, analyticsCookieDomain);
+    const cookies = window.GOVSignIn.Cookies(trackingId, analyticsCookieDomain);
 
     if (cookies.hasConsentForAnalytics()) {
       cookies.initAnalytics();
@@ -36,9 +44,9 @@ initChangePhoneNumber();
   }
 
   if (w.GOVUK && w.GOVUK.Modules && w.GOVUK.Modules.ShowPassword) {
-    var modules = document.querySelectorAll('[data-module="show-password"]');
+    const modules = document.querySelectorAll('[data-module="show-password"]');
 
-    for (var i = 0, l = modules.length; i < l; i++) {
+    for (let i = 0, l = modules.length; i < l; i++) {
       if (GOVUK.Modules.ShowPassword.prototype.init) {
         new GOVUK.Modules.ShowPassword(modules[i]).init();
       }


### PR DESCRIPTION
### What changed

Replaced the `var` keyword with either `let` or `const`.

### Why did it change

Using the `var` keywords creates a code smell since it is outdated syntax.

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
