### PR TITLE
[ATB-209] Replaced var keyword with let or const

### DIFF
--- a/src/assets/javascript/showPassword.js
+++ b/src/assets/javascript/showPassword.js
@@ -50,7 +50,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.moveDataAttributesToButton();
 
     this.parentForm = this.input.form;
-    var disableFormSubmitCheck = this.$module.getAttribute(
+    const disableFormSubmitCheck = this.$module.getAttribute(
       "data-disable-form-submit-check"
     );
 
@@ -92,9 +92,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   };
 
   ShowPassword.prototype.moveDataAttributesToButton = function () {
-    var attrs = this.input.attributes;
-    for (var i = attrs.length; i >= 0; i--) {
-      var attr = attrs[i];
+    let attrs = this.input.attributes;
+    for (let i = attrs.length; i >= 0; i--) {
+      let attr = attrs[i];
       if (attr && /^data-button/.test(attr.name)) {
         this.showHide.setAttribute(
           attr.name.replace("-button", ""),


### PR DESCRIPTION
### What changed

Replaced the `var` keyword with either `let` or `const`.

### Why did it change

Using the `var` keywords creates a code smell since it is outdated syntax.

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed