### PR TITLE
GUA-524 update github actions to versions that use node16

### DIFF
--- a/.github/workflows/build-test-application.yml
+++ b/.github/workflows/build-test-application.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.17.0
+          node-version-file: .node-version
 
       - name: Install dependencies defined in yarn.lock
         run: yarn install --frozen-lockfile

--- a/.github/workflows/cd-only.yml
+++ b/.github/workflows/cd-only.yml
@@ -50,7 +50,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     needs: validate_artifacts
     steps:
       - name: "Push signed image to ECR, updated SAM template wih image then upload it to the S3 Artifact Bucket"
-        uses: alphagov/di-devplatform-upload-action-ecr@1.0.1
+        uses: alphagov/di-devplatform-upload-action-ecr@1.0.2
         with:
           artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}

--- a/.github/workflows/pre-merge-checks-terraform.yml
+++ b/.github/workflows/pre-merge-checks-terraform.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get Terraform version
         id: getterraformversion
-        run: echo "::set-output name=version::$(cat ci/terraform/.terraform-version)"
+        run: echo "name=version::$(cat ci/terraform/.terraform-version)" >> $GITHUB_OUTPUT
 
       - uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/validate-docker-image.yml
+++ b/.github/workflows/validate-docker-image.yml
@@ -42,7 +42,7 @@ jobs:
 #        run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H:%M:%S')"
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2

--- a/.github/workflows/validate-sam-template.yml
+++ b/.github/workflows/validate-sam-template.yml
@@ -35,10 +35,10 @@ jobs:
         with:
           ref: ${{ inputs.gitRef || github.ref }}
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Set up SAM cli
         uses: aws-actions/setup-sam@v2
@@ -47,7 +47,7 @@ jobs:
         run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2


### PR DESCRIPTION
## Proposed changes
Updating github workflow actions to versions written in Node 16.

### Why did it change
Github is deprecating Node12 and for security deprecating the set-output function.

## Checklists
Checked workflows that are triggered when branch is pushed, when deploying to dev, and when raising PR. 
Workflows triggered on merge to main can only be confirmed when this PR is merged. 

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

### Other considerations
- [x] Demo to a BA, TA, and the team.
- [x] Recorded demo shared on [#govuk-accounts-tech](https://gds.slack.com/archives/C011Y5SAY3U)
- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
